### PR TITLE
Fixing "sirenComponent.delete is not a function"

### DIFF
--- a/state/HypermediaState.js
+++ b/state/HypermediaState.js
@@ -35,7 +35,7 @@ export class HypermediaState {
 	dispose(component) {
 		this._decodedEntity.forEach(typeMap => {
 			typeMap.forEach(sirenComponent => {
-				sirenComponent.deleteComponent(component);
+				sirenComponent.delete(component);
 			});
 		});
 	}

--- a/state/sirenComponents/SirenAction.js
+++ b/state/sirenComponents/SirenAction.js
@@ -47,7 +47,7 @@ export class SirenAction {
 		}
 	}
 
-	deleteComponent(component) {
+	delete(component) {
 		this._components.delete(component);
 	}
 

--- a/state/sirenComponents/SirenClasses.js
+++ b/state/sirenComponents/SirenClasses.js
@@ -22,7 +22,7 @@ export class SirenClasses {
 		this._components.setComponentProperty(component, this.value);
 	}
 
-	deleteComponent(component) {
+	delete(component) {
 		this._components.delete(component);
 	}
 

--- a/state/sirenComponents/SirenEntity.js
+++ b/state/sirenComponents/SirenEntity.js
@@ -21,7 +21,7 @@ export class SirenEntity {
 		this._components.setComponentProperty(component, this.sirenEntity);
 	}
 
-	deleteComponent(component) {
+	delete(component) {
 		this._components.delete(component);
 	}
 

--- a/state/sirenComponents/SirenLink.js
+++ b/state/sirenComponents/SirenLink.js
@@ -36,7 +36,7 @@ export class SirenLink {
 		return this._childState;
 	}
 
-	deleteComponent(component) {
+	delete(component) {
 		if (this._routes.has(component)) {
 			this._childState.dispose(component);
 			this._routes.delete(component);

--- a/state/sirenComponents/SirenProperty.js
+++ b/state/sirenComponents/SirenProperty.js
@@ -28,7 +28,7 @@ export class SirenProperty {
 		this._components.setComponentProperty(component, this.value);
 	}
 
-	deleteComponent(component) {
+	delete(component) {
 		this._components.delete(component);
 	}
 

--- a/state/sirenComponents/SirenSubEntities.js
+++ b/state/sirenComponents/SirenSubEntities.js
@@ -40,7 +40,7 @@ export class SirenSubEntities {
 		return this._childSubEntities;
 	}
 
-	deleteComponent(component) {
+	delete(component) {
 		if (this._route.has(component)) {
 			this._childState.dispose(component);
 			this._route.delete(component);

--- a/state/sirenComponents/SirenSubEntity.js
+++ b/state/sirenComponents/SirenSubEntity.js
@@ -34,6 +34,15 @@ export class SirenSubEntity {
 		return this._childState;
 	}
 
+	delete(component) {
+		if (this._routes.has(component)) {
+			this._childState.dispose(component);
+			this._routes.delete(component);
+			return;
+		}
+		this._components.delete(component);
+	}
+
 	get rel() {
 		return this._rel;
 	}


### PR DESCRIPTION
## Context
<img width="706" alt="Screen Shot 2020-10-21 at 12 25 36 PM" src="https://user-images.githubusercontent.com/2412740/96766835-a98e2d00-13a9-11eb-8491-3384d616b995.png">

## Changes
- Renames `deleteComponent` to `delete` for all sirenComponents (to become `Observables`)
- Adds delete function to `SirenSubEntity`

## Quality
- Manually tested with `polarisdev` sitelord instance and local BSI