### PR TITLE
Fetchable mixin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+
+[{*.json,*.yml}]
+indent_style = space
+indent_size = 2

--- a/state/Fetchable.js
+++ b/state/Fetchable.js
@@ -1,0 +1,140 @@
+import { refreshToken } from './token.js';
+
+/**
+ * FetchError
+ * Custom error type for errors associated with Fetchable objects
+ */
+export class FetchError extends Error {}
+
+/**
+ * FetchStatus
+ * Object for tracking the pending status of an object
+ * @property {Promise} complete Promise that resolves when the fetch is complete
+ * @property {Boolean} pending Whether the fetch has started
+ */
+class FetchStatus {
+	constructor() {
+		this.complete = null;
+		this.pending = false;
+	}
+
+	/**
+	 * Resolves Promise to null and sets pending status to false
+	 */
+	cancel() {
+		if (!this.pending) throw new FetchError('Cannot call cancel() on a status that is not pending');
+		this._resolver(null);
+		this.pending = false;
+	}
+
+	/**
+	 * Resolves Promise to true and sets pending status to false
+	 */
+	done() {
+		if (!this.pending) throw new FetchError('Cannot call done() on a status that is not pending');
+		this._resolver(true);
+		this.pending = false;
+	}
+
+	/**
+	 * Creates a Promise and sets pending status to true
+	 */
+	start() {
+		this.complete = new Promise(resolve => this._resolver = resolve);
+		this.pending = true;
+	}
+}
+
+/**
+ * Fetchable mixin
+ * Behaviour interface for objects that can be fetched from the server
+ * @mixin
+ */
+export const Fetchable = superclass => class extends superclass {
+
+	/**
+	 * @param {String} href The href to fetch the object from
+	 * @param {Token} token The token object associated with the item
+	 */
+	constructor(href, token) {
+		super();
+		this._body = null;
+		this._fetchStatus = new FetchStatus();
+		this._headers = null;
+		this._href = href;
+		this._token = token;
+	}
+
+	/**
+	 * @returns {Object} The body of the request
+	 */
+	get body() {
+		return this._body;
+	}
+
+	/**
+	 * @returns {FetchStatus} Status object for the fetch
+	 */
+	get fetchStatus() {
+		return this._fetchStatus;
+	}
+
+	/**
+	 * @returns {Headers} Headers for the request
+	 */
+	get headers() {
+		if (!this._headers) this._initHeaders();
+		return this._headers;
+	}
+
+	/**
+	 * @returns {String} href that identifies the fetchable
+	 */
+	get href() {
+		return this._href;
+	}
+
+	/**
+	 * @returns {String} The method to be used in the request. Default is GET
+	 */
+	get method() {
+		return 'GET';
+	}
+
+	/**
+	 * Refreshes the token object
+	 * @returns {Promise}
+	 */
+	async refreshToken() {
+		await refreshToken(this.token);
+	}
+
+	/**
+	 * @param {Object} paramsObj An object representing key value pairs or lists of query parameters
+	 * E.g. { key: 'input-for-key' } or { key: ['input1', 'input2']}
+	 * @returns {String} A URL containing the query string
+	 */
+	setQueryParams(paramsObj) {
+		let url = new URL(this.href, window.location.origin);
+		const params = new URLSearchParams(Object.keys(paramsObj).map(field => [field, paramsObj[field]]));
+		url = new URL(`${url.pathname}?${params.toString()}`, url.origin);
+		this._href = url.toString();
+		return this._href;
+	}
+
+	/**
+	 * @returns {Token} Token object associated with the object
+	 */
+	get token() {
+		return this._token;
+	}
+
+	/**
+	 * Initializes the headers for the fetch
+	 */
+	_initHeaders() {
+		const headers = new Headers();
+		!this.token.cookie && headers.set('Authorization', `Bearer ${this.token.value}`);
+		this._headers = headers;
+	}
+};

--- a/state/HypermediaState.js
+++ b/state/HypermediaState.js
@@ -1,5 +1,5 @@
 import { observableTypes as ot, sirenComponentBasicInfo, sirenComponentFactory } from './sirenComponents/sirenComponentFactory.js';
-import { refreshToken } from './token.js';
+import { Fetchable } from './Fetchable.js';
 
 export const observableTypes = ot;
 
@@ -8,10 +8,9 @@ export const observableTypes = ot;
  * @export
  * @class HypermediaState
  */
-export class HypermediaState {
+export class HypermediaState extends Fetchable(Object) {
 	constructor(entityId, token) {
-		this._entityId = entityId;
-		this._token = token;
+		super(entityId, token);
 
 		this._decodedEntity = new Map();
 	}
@@ -41,7 +40,7 @@ export class HypermediaState {
 	}
 
 	get entityId() {
-		return this._entityId;
+		return this.href;
 	}
 
 	hasServerResponseCached() {
@@ -59,10 +58,6 @@ export class HypermediaState {
 		actions.forEach(action => action.push());
 	}
 
-	refreshToken() {
-		return refreshToken(this.token);
-	}
-
 	reset() {
 		this._childStates().forEach(childState => childState?.reset());
 		this.setSirenEntity();
@@ -77,10 +72,6 @@ export class HypermediaState {
 				sirenComponent.setSirenEntity(this._entity, typeMap);
 			});
 		});
-	}
-
-	get token() {
-		return this._token;
 	}
 
 	updateProperties(observables) {

--- a/state/observable/SirenAction.js
+++ b/state/observable/SirenAction.js
@@ -32,6 +32,7 @@ export class SirenAction extends Fetchable(Observable) {
 	}
 
 	get headers() {
+		super.headers;
 		// set header content to json if present
 		if (this._rawSirenAction.type.indexOf('json') !== -1) {
 			this._headers.set('Content-Type', this._rawSirenAction.type);

--- a/state/observable/SirenAction.js
+++ b/state/observable/SirenAction.js
@@ -4,7 +4,7 @@ import { performAction } from '../store.js';
 
 export class SirenAction extends Fetchable(Observable) {
 	constructor({ id: name, token, state }) {
-		super(state?.href, token);
+		super(null, token);
 		this._action = { has: false, perform: () => undefined, update: () => undefined };
 		this._name = name;
 		this._state = state;
@@ -71,6 +71,7 @@ export class SirenAction extends Fetchable(Observable) {
 		}
 
 		this._rawSirenAction = sirenEntity.getActionByName(this._name);
+		this._href = this._rawSirenAction.href;
 		this._fields = this._decodeFields(this._rawSirenAction);
 
 		this.action = {

--- a/test/Fetchable.test.js
+++ b/test/Fetchable.test.js
@@ -1,0 +1,57 @@
+import { Fetchable, FetchError } from '../state/Fetchable.js';
+import { expect }  from '@open-wc/testing';
+
+class TestObject extends Fetchable(Object) {}
+
+describe('FetchStatus', () => {
+	let status;
+	beforeEach(() => status = (new TestObject()).fetchStatus);
+
+	it('starts and completes the status', () => {
+		expect(status.complete).to.be.null;
+		status.start();
+		expect(typeof status.complete).to.be.equal('object');
+
+		status.done();
+		status.complete.then(result => expect(result).to.be.true);
+	});
+
+	it('starts and cancels the status', () => {
+		expect(status.complete).to.be.null;
+		status.start();
+		expect(typeof status.complete).to.be.equal('object');
+
+		status.cancel();
+		status.complete.then(result => expect(result).to.be.null);
+	});
+
+	it('throws error if attempting to cancel or finish a non-started status', () => {
+		expect(() => status.done()).to.throw(FetchError);
+		expect(() => status.cancel()).to.throw(FetchError);
+	});
+});
+
+describe('Fetchable', () => {
+
+	let obj;
+	beforeEach(() => obj = new TestObject('http://test.com', 'sometoken'));
+
+	it('sets the href with query parameters', () => {
+		expect(obj.href).to.be.equal('http://test.com');
+
+		const paramObj = {
+			'field1': 'value1',
+			'field2': ['value2', 'value3']
+		};
+		const urlComma = encodeURIComponent(',');
+		obj.setQueryParams(paramObj);
+		expect(obj.href).to.be.equal(`http://test.com/?field1=value1&field2=value2${urlComma}value3`);
+	});
+
+	it('sets the href with new parameters when previously set', () => {
+		obj.setQueryParams({ 'key': 'value' });
+		expect(obj.href).to.be.equal('http://test.com/?key=value');
+		obj.setQueryParams({ 'newKey': 'newValue' });
+		expect(obj.href).to.be.equal('http://test.com/?newKey=newValue');
+	});
+});


### PR DESCRIPTION
## Context
[US121368](https://rally1.rallydev.com/#/detail/userstory/441183090652?fdp=true): Creation of Fetchable mixin
[Architecture Design](https://desire2learn.atlassian.net/wiki/spaces/POL/pages/1622278478/US120980+Defining+the+architecture+of+hmc-foundation)
Adds the `Fetchable` mixin which functions as an abstract class for use with the in progress `fetch` method.

- `fetchStatus` is now an object attached to the `Fetchable` with `start()`, `cancel()`, and `done()` methods
- `observable/SirenAction` and `HypermediaState` both implement `Fetchable`
- `href(input)` method converted to `setQueryParams` method
- `header()` method converted to `headers` getter
- Snuck a `.editorconfig` file in there because it was causing problems not having one

## Quality
- added new unit tests for `FetchStatus`
- added basic tests for `Fetchable.setQueryParams()`
- manually tested with BSI branch

**Note**
There is an existing error in `master` related to `sirenAction`. I didn't want to fix it in this PR because of the current work in flight.
<img width="767" alt="Screen Shot 2020-10-26 at 2 58 46 PM" src="https://user-images.githubusercontent.com/2412740/97217750-1d5f7980-179e-11eb-977e-895d09945384.png">
