### PR TITLE
Added generic setValue method to Observable

### DIFF
--- a/state/observable/Observable.js
+++ b/state/observable/Observable.js
@@ -1,16 +1,14 @@
-import { Component } from './Common.js';
+import { ObserverMap } from './ObserverMapjs';
 //import { defaultBasicInfo } from 'sirenComponentFactory.js';
 
 export class Observable {
 
-	// TODO: change to ObserverMap in US121366
 	constructor() {
-		this._observers = new Component(); // new ObserverMap()
+		this._observers = new ObserverMap();
 	}
 
 	addObserver(observer, property, { method }, value) {
-		this._observers.add(observer, property, method);
-		this._observers.setObserverProperty(observer, value);
+		this._observers.add(observer, property, method, value);
 	}
 
 	deleteObserver(observer) {

--- a/state/observable/Observable.js
+++ b/state/observable/Observable.js
@@ -1,5 +1,4 @@
 import { ObserverMap } from './ObserverMapjs';
-//import { defaultBasicInfo } from 'sirenComponentFactory.js';
 
 export class Observable {
 

--- a/state/observable/Observable.js
+++ b/state/observable/Observable.js
@@ -15,6 +15,12 @@ export class Observable {
 	}
 	setSirenEntity() {}
 
+	setValue(oldValue, newValue) {
+		if (oldValue !== newValue) {
+			this._observers.setProperty(newValue);
+		}
+	}
+
 	_addRoute(observer, route) {
 		const currentRoute = this._routes.has(observer) ? this._routes.get(observer) : {};
 		this._routes.set(observer, { ...currentRoute, ...route });

--- a/state/observable/ObserverMap.js
+++ b/state/observable/ObserverMap.js
@@ -5,34 +5,34 @@ export class ObserverMap {
 		this.value = {};
 	}
 
-	add(component, property, method, value) {
-		if (this._observers.has(component)) {
+	add(observer, property, method, value) {
+		if (this._observers.has(observer)) {
 			return;
 		}
 
 		this.value = value;
-		this._observers.set(component, property);
-		method && this._methods.set(component, method);
-		this._setObserverProperty(component, value);
+		this._observers.set(observer, property);
+		method && this._methods.set(observer, method);
+		this._setObserverProperty(observer, value);
 	}
 
-	delete(component) {
-		this._methods.delete(component);
-		return this._observers.delete(component);
+	delete(observer) {
+		this._methods.delete(observer);
+		return this._observers.delete(observer);
 	}
 
 	setProperty(value) {
 		this.value = value;
 
-		this._observers.forEach((property, component) => {
-			const method = this._methods.has(component) && this._methods.get(component);
-			component[property] = method ? method(this.value) : this.value;
+		this._observers.forEach((property, observer) => {
+			const method = this._methods.has(observer) && this._methods.get(observer);
+			observer[property] = method ? method(this.value) : this.value;
 		});
 	}
 
-	_setObserverProperty(component) {
-		const method = this._methods.has(component) && this._methods.get(component);
-		component[this._observers.get(component)] = method ? method(this.value) : this.value;
+	_setObserverProperty(observer) {
+		const method = this._methods.has(observer) && this._methods.get(observer);
+		observer[this._observers.get(observer)] = method ? method(this.value) : this.value;
 	}
 
 }

--- a/state/observable/ObserverMap.js
+++ b/state/observable/ObserverMap.js
@@ -1,0 +1,43 @@
+export class ObserverMap {
+	constructor() {
+		this._observers = new Map();
+		this._methods = new WeakMap();
+		this.value = {};
+	}
+
+	add(component, property, method, value) {
+		if (this._observers.has(component)) {
+			return;
+		}
+
+		this.value = value;
+		this._observers.set(component, property);
+		method && this._methods.set(component, method);
+		this._setObserverProperty(component, value);
+	}
+
+	delete(component) {
+		this._methods.delete(component);
+		return this._observers.delete(component);
+	}
+
+	setProperty(value) {
+		this.value = value;
+
+		this._observers.forEach((property, component) => {
+			const method = this._methods.has(component) && this._methods.get(component);
+			component[property] = method ? method(this.value) : this.value;
+		});
+	}
+
+	_setObserverProperty(component) {
+		const method = this._methods.has(component) && this._methods.get(component);
+		component[this._observers.get(component)] = method ? method(this.value) : this.value;
+	}
+
+}
+
+export function getEntityIdFromSirenEntity(entity) {
+	const self = entity.hasLinkByRel && entity.hasLinkByRel('self') && entity.getLinkByRel && entity.getLinkByRel('self');
+	return  entity.href || (self && self.href);
+}

--- a/state/observable/SirenAction.js
+++ b/state/observable/SirenAction.js
@@ -11,7 +11,7 @@ export class SirenAction extends Fetchable(Observable) {
 	}
 
 	get action() {
-		return this._components.value || { has: false, perform: () => undefined, update: () => undefined };
+		return this._observers.value || { has: false, perform: () => undefined, update: () => undefined };
 	}
 
 	set action({ has, perform, update }) {
@@ -20,15 +20,15 @@ export class SirenAction extends Fetchable(Observable) {
 			update = () => undefined;
 		}
 		if (this.action().has !== has || this.action().perform !== perform) {
-			this._components.setProperty({ has, perform, update });
+			this._observers.setProperty({ has, perform, update });
 		}
 
 		this._action = { has, perform, update };
 	}
 
 	// TODO: remove in US121366
-	addObserver(component, property, { method }) {
-		super.addObserver(component, property, method, this.action);
+	addObserver(observer, property, { method }) {
+		super.addObserver(observer, property, method, this.action);
 	}
 
 	get headers() {

--- a/state/observable/SirenAction.js
+++ b/state/observable/SirenAction.js
@@ -5,14 +5,13 @@ import { refreshToken } from '../token.js';
 export class SirenAction extends Observable {
 	constructor({ id: name, token, state }) {
 		super();
-		this._action = { has: false, perform: () => undefined, update: () => undefined };
 		this._name = name;
 		this._token = token;
 		this._state = state;
 	}
 
 	get action() {
-		return this._action;
+		return this._components.value || { has: false, perform: () => undefined, update: () => undefined };
 	}
 
 	set action({ has, perform, update }) {
@@ -20,12 +19,9 @@ export class SirenAction extends Observable {
 			perform = () => undefined;
 			update = () => undefined;
 		}
-		if (this._action.has !== has || this._action.perform !== perform) {
+		if (this.action().has !== has || this.action().perform !== perform) {
 			this._components.setProperty({ has, perform, update });
 		}
-
-		this._action = { has, perform, update };
-
 	}
 
 	// TODO: remove in US121366

--- a/state/observable/SirenClasses.js
+++ b/state/observable/SirenClasses.js
@@ -6,9 +6,7 @@ export class SirenClasses extends Observable {
 	}
 
 	set value(value) {
-		if (!this.value() !== value) {
-			this._observers.setProperty(value);
-		}
+		this.setValue(!this.value(), value);
 	}
 
 	// TODO: remove in future

--- a/state/observable/SirenClasses.js
+++ b/state/observable/SirenClasses.js
@@ -2,14 +2,13 @@ import { Observable } from './Observable.js';
 
 export class SirenClasses extends Observable {
 	get value() {
-		return this._value;
+		return this._observers.value;
 	}
 
 	set value(value) {
-		if (!this._value !== value) {
+		if (!this.value() !== value) {
 			this._observers.setProperty(value);
 		}
-		this._value = value;
 	}
 
 	// TODO: remove in future

--- a/state/observable/SirenEntity.js
+++ b/state/observable/SirenEntity.js
@@ -7,9 +7,7 @@ export class SirenEntity extends Observable {
 	}
 
 	set sirenEntity(sirenEntity) {
-		if (!this.sirenEntity() !== sirenEntity) {
-			this._observers.setProperty(sirenEntity);
-		}
+		this.setValue(!this.sirenEntity(), sirenEntity);
 	}
 
 	// TODO: remove in US121366

--- a/state/observable/SirenEntity.js
+++ b/state/observable/SirenEntity.js
@@ -3,14 +3,13 @@ import { Observable } from './Observable.js';
 export class SirenEntity extends Observable {
 
 	get sirenEntity() {
-		return this._sirenEntity;
+		return this._observers.value;
 	}
 
 	set sirenEntity(sirenEntity) {
-		if (!this._sirenEntity !== sirenEntity) {
+		if (!this.sirenEntity() !== sirenEntity) {
 			this._observers.setProperty(sirenEntity);
 		}
-		this._sirenEntity = sirenEntity;
 	}
 
 	// TODO: remove in US121366

--- a/state/observable/SirenLink.js
+++ b/state/observable/SirenLink.js
@@ -11,15 +11,13 @@ export class SirenLink extends Observable {
 	}
 
 	get link() {
-		return this._link;
+		return this._observers.value;
 	}
 
 	set link(link) {
-		if (!this._link !== link) {
+		if (!this.link() !== link) {
 			this._observers.setProperty(link && link.href);
 		}
-		this._link = link;
-
 	}
 
 	// TODO: remove in US121366

--- a/state/observable/SirenLink.js
+++ b/state/observable/SirenLink.js
@@ -15,9 +15,7 @@ export class SirenLink extends Observable {
 	}
 
 	set link(link) {
-		if (!this.link() !== link) {
-			this._observers.setProperty(link && link.href);
-		}
+		this.setValue(!this.link(), link && link.href);
 	}
 
 	// TODO: remove in US121366

--- a/state/observable/SirenProperty.js
+++ b/state/observable/SirenProperty.js
@@ -12,15 +12,13 @@ export class SirenProperty extends Observable {
 	}
 
 	get value() {
-		return this._value;
+		return this._observers.value;
 	}
 
 	set value(value) {
-		if (!this._value !== value) {
+		if (!this.value() !== value) {
 			this._observers.setProperty(value);
 		}
-		this._value = value;
-
 	}
 
 	// TODO: remove in US121366

--- a/state/observable/SirenProperty.js
+++ b/state/observable/SirenProperty.js
@@ -16,9 +16,7 @@ export class SirenProperty extends Observable {
 	}
 
 	set value(value) {
-		if (!this.value() !== value) {
-			this._observers.setProperty(value);
-		}
+		this.setValue(!this.value, value);
 	}
 
 	// TODO: remove in US121366

--- a/state/observable/SirenSubEntities.js
+++ b/state/observable/SirenSubEntities.js
@@ -19,9 +19,7 @@ export class SirenSubEntities extends Observable {
 	}
 
 	set entityIds(entityIds) {
-		if (!this.entityIds() !== entityIds) {
-			this._observers.setProperty(entityIds || []);
-		}
+		this.setValue(!this.entityIds(), entityIds || []);
 	}
 
 	// TODO: remove in US121366

--- a/state/observable/SirenSubEntities.js
+++ b/state/observable/SirenSubEntities.js
@@ -12,18 +12,16 @@ export class SirenSubEntities extends Observable {
 		this._rel = id;
 		this._childSubEntities = new Map();
 		this._token = token;
-		this._entityIds = [];
 	}
 
 	get entityIds() {
-		return this._entityIds;
+		return this._observers.value;
 	}
 
 	set entityIds(entityIds) {
-		if (!this._entityId !== entityIds) {
+		if (!this.entityIds() !== entityIds) {
 			this._observers.setProperty(entityIds || []);
 		}
-		this._entityIds = entityIds || [];
 	}
 
 	// TODO: remove in US121366

--- a/state/observable/SirenSubEntity.js
+++ b/state/observable/SirenSubEntity.js
@@ -15,9 +15,7 @@ export class SirenSubEntity extends Observable {
 	}
 
 	set entityId(entityId) {
-		if (!this.entityId() !== entityId) {
-			this._observers.setProperty(entityId);
-		}
+		this.setValue(!this.entityId, entityId);
 	}
 
 	// TODO: remove in US121366?

--- a/state/observable/SirenSubEntity.js
+++ b/state/observable/SirenSubEntity.js
@@ -11,14 +11,13 @@ export class SirenSubEntity extends Observable {
 	}
 
 	get entityId() {
-		return this._entityId;
+		return this._observers.value;
 	}
 
 	set entityId(entityId) {
-		if (!this._entityId !== entityId) {
+		if (!this.entityId() !== entityId) {
 			this._observers.setProperty(entityId);
 		}
-		this._entityId = entityId;
 	}
 
 	// TODO: remove in US121366?

--- a/test/observerMap.test.js
+++ b/test/observerMap.test.js
@@ -1,0 +1,74 @@
+import { expect }  from '@open-wc/testing';
+import { ObserverMap } from '../state/observable/ObserverMap.js';
+
+describe('ObserverMap', () => {
+
+	let observerMap;
+
+	beforeEach(() => {
+		observerMap = new ObserverMap();
+	});
+
+	describe('should add an observer', () => {
+		it('should add object by ref with key to be updated', async() => {
+			const component = {
+				'bar': 'foo'
+			};
+			const proprety = 'proprety';
+			const method = undefined;
+			const value = 'href';
+
+			observerMap.add(component, proprety, method, value);
+
+			expect(observerMap._observers.has(component)).to.be.true;
+			const getProprety = observerMap._observers.get(component);
+			expect(getProprety).to.be.equal(proprety);
+		});
+
+		it('should set value when adding a component', async() => {
+			const component = {
+				'bar': 'foo'
+			};
+			const proprety = 'proprety';
+			const method = undefined;
+			const value = 'href';
+
+			observerMap.add(component, proprety, method, value);
+
+			expect(observerMap.value).to.be.equal(value);
+			expect(component[proprety]).to.be.equal(value);
+		});
+
+	});
+
+	it('should delete a component', async() => {
+		const component = {
+			'bar': 'foo'
+		};
+		const proprety = 'proprety';
+		const method = undefined;
+		const value = 'href';
+
+		observerMap.add(component, proprety, method, value);
+		observerMap.delete(component);
+
+		expect(observerMap._observers.has(component)).to.be.false;
+		expect(component[proprety]).to.be.equal(value); //should this be removed
+	});
+
+	it('should update all object with new value', async() => {
+		const component = {
+			'bar': 'foo'
+		};
+		const proprety = 'proprety';
+		const method = undefined;
+		const value = 'href';
+		const newValue = 'newHref';
+
+		observerMap.add(component, proprety, method, value);
+		observerMap.setProperty(newValue);
+
+		expect(component[proprety]).to.be.equal(newValue);
+	});
+
+});

--- a/test/observerMap.test.js
+++ b/test/observerMap.test.js
@@ -11,53 +11,53 @@ describe('ObserverMap', () => {
 
 	describe('should add an observer', () => {
 		it('should add object by ref with key to be updated', async() => {
-			const component = {
+			const observer = {
 				'bar': 'foo'
 			};
 			const proprety = 'proprety';
 			const method = undefined;
 			const value = 'href';
 
-			observerMap.add(component, proprety, method, value);
+			observerMap.add(observer, proprety, method, value);
 
-			expect(observerMap._observers.has(component)).to.be.true;
-			const getProprety = observerMap._observers.get(component);
+			expect(observerMap._observers.has(observer)).to.be.true;
+			const getProprety = observerMap._observers.get(observer);
 			expect(getProprety).to.be.equal(proprety);
 		});
 
-		it('should set value when adding a component', async() => {
-			const component = {
+		it('should set value when adding a observer', async() => {
+			const observer = {
 				'bar': 'foo'
 			};
 			const proprety = 'proprety';
 			const method = undefined;
 			const value = 'href';
 
-			observerMap.add(component, proprety, method, value);
+			observerMap.add(observer, proprety, method, value);
 
 			expect(observerMap.value).to.be.equal(value);
-			expect(component[proprety]).to.be.equal(value);
+			expect(observer[proprety]).to.be.equal(value);
 		});
 
 	});
 
-	it('should delete a component', async() => {
-		const component = {
+	it('should delete a observer', async() => {
+		const observer = {
 			'bar': 'foo'
 		};
 		const proprety = 'proprety';
 		const method = undefined;
 		const value = 'href';
 
-		observerMap.add(component, proprety, method, value);
-		observerMap.delete(component);
+		observerMap.add(observer, proprety, method, value);
+		observerMap.delete(observer);
 
-		expect(observerMap._observers.has(component)).to.be.false;
-		expect(component[proprety]).to.be.equal(value); //should this be removed
+		expect(observerMap._observers.has(observer)).to.be.false;
+		expect(observer[proprety]).to.be.equal(value); //should this be removed
 	});
 
 	it('should update all object with new value', async() => {
-		const component = {
+		const observer = {
 			'bar': 'foo'
 		};
 		const proprety = 'proprety';
@@ -65,10 +65,10 @@ describe('ObserverMap', () => {
 		const value = 'href';
 		const newValue = 'newHref';
 
-		observerMap.add(component, proprety, method, value);
+		observerMap.add(observer, proprety, method, value);
 		observerMap.setProperty(newValue);
 
-		expect(component[proprety]).to.be.equal(newValue);
+		expect(observer[proprety]).to.be.equal(newValue);
 	});
 
 });


### PR DESCRIPTION
US121364/US121366

After reviewing pull requests and writing tests, I observed that this set method would probably be useful in the Observable class now that value is stored in ObserberMaps.

Changes
- added setValue to Observable
- changed most Observable subclasses to call setValue with appropriate params