### PR TITLE
test: Added coverage configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,4 @@
 {
-    "extends": "brightspace/lit-config"
-  }
-
-  
+  "extends": "brightspace/lit-config",
+  "ignorePatterns": ["coverage/**/*"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 package-lock.json
+.nyc_output
+coverage/

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@brightspace-hmc/foundation-engine",
   "version": "0.0.1",
-  "description": "engine for foundation-hmc",
+  "description": "engine for foundation hypermedia components",
   "scripts": {
-    "test": "npm run lint && npm run test:headless",
     "lint": "eslint . --ext .js,.html",
-    "test:headless": "karma start",
+    "test": "npm run lint && npm run test:headless",
+    "test:headless": "karma start --coverage",
     "test:sauce": "karma start karma.sauce.conf.js"
   },
   "repository": {

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-	"extends": "brightspace/open-wc-testing-config"
+  "extends": "brightspace/open-wc-testing-config"
 }


### PR DESCRIPTION
## Context
[US121576](https://rally1.rallydev.com/#/detail/userstory/447027030140?fdp=true)
Fun fact: `open-wc/testing-karma` comes with `istanbul` coverage built in. You just have to pass a flag.

As expected, our code coverage sucks right now, but now we can measure how badly it sucks 🥇 

<img width="580" alt="Screen Shot 2020-12-01 at 1 14 56 PM" src="https://user-images.githubusercontent.com/2412740/100780260-8064b180-33d7-11eb-8022-243701d97ecf.png">
<img width="771" alt="Screen Shot 2020-12-01 at 1 04 22 PM" src="https://user-images.githubusercontent.com/2412740/100780277-83f83880-33d7-11eb-8e94-3b3c7fee632c.png">
