### PR TITLE
Add merge method to ObserverMap

### DIFF
--- a/state/observable/ObserverMap.js
+++ b/state/observable/ObserverMap.js
@@ -36,9 +36,9 @@ export class ObserverMap {
 		return this._observers.delete(observer);
 	}
 
-	merge(map) {
-		map._observers.forEach((property, observer) => {
-			this.add(observer, property, map._methods.get(observer));
+	merge(observerMap) {
+		observerMap._observers.forEach((property, observer) => {
+			this.add(observer, property, observerMap._methods.get(observer));
 		});
 	}
 

--- a/state/observable/ObserverMap.js
+++ b/state/observable/ObserverMap.js
@@ -36,6 +36,12 @@ export class ObserverMap {
 		return this._observers.delete(observer);
 	}
 
+	merge(map) {
+		map._observers.forEach((observer, property) => {
+			this.addObserver(observer, property, map._methods.get(observer));
+		});
+	}
+
 	setProperty(value) {
 		this._value = value;
 

--- a/state/observable/ObserverMap.js
+++ b/state/observable/ObserverMap.js
@@ -37,8 +37,8 @@ export class ObserverMap {
 	}
 
 	merge(map) {
-		map._observers.forEach((observer, property) => {
-			this.addObserver(observer, property, map._methods.get(observer));
+		map._observers.forEach((property, observer) => {
+			this.add(observer, property, map._methods.get(observer));
 		});
 	}
 

--- a/state/observable/SirenAction.js
+++ b/state/observable/SirenAction.js
@@ -28,8 +28,6 @@ export class SirenAction extends Fetchable(Observable) {
 		if (this.action.has !== has || this.action.commit !== commit) {
 			this._observers.setProperty({ has, commit });
 		}
-
-		this._observers.value = { has, commit };
 	}
 
 	get headers() {

--- a/state/observable/SirenAction.js
+++ b/state/observable/SirenAction.js
@@ -28,6 +28,8 @@ export class SirenAction extends Fetchable(Observable) {
 		if (this.action.has !== has || this.action.commit !== commit) {
 			this._observers.setProperty({ has, commit });
 		}
+
+		this._observers.value = { has, commit };
 	}
 
 	get headers() {

--- a/state/observable/SirenLink.js
+++ b/state/observable/SirenLink.js
@@ -75,10 +75,7 @@ export class SirenLink extends Observable {
 			return;
 		}
 
-		sirenLink._observers._observers.forEach((observer, property) => {
-			this.addObserver(observer, property);
-		});
-
+		this._observers.merge(sirenLink._observers);
 		this._token = this._token || sirenLink._token;
 	}
 }

--- a/state/observable/SirenSubEntity.js
+++ b/state/observable/SirenSubEntity.js
@@ -68,10 +68,7 @@ export class SirenSubEntity extends Observable {
 			return;
 		}
 
-		entity._observers._observers.forEach((observer, property) => {
-			this.addObserver(observer, property);
-		});
-
+		this._observers.merge(entity._observers);
 		this._token = this._token || entity._token;
 	}
 

--- a/test/observerMap.test.js
+++ b/test/observerMap.test.js
@@ -64,13 +64,140 @@ describe('ObserverMap', () => {
 		};
 		const property = 'property';
 		const method = undefined;
-		const value = 'href';
 		const newValue = 'newHref';
 
-		observerMap.add(observer, property, method, value);
+		observerMap.add(observer, property, method);
 		observerMap.setProperty(newValue);
 
 		assert(observer[property] === newValue);
 	});
 
+	describe('should merge observers', () => {
+		let observerMap2;
+		beforeEach(() => {
+			observerMap2 = new ObserverMap();
+		});
+
+		it('should merge two observers, only the one merged to is altered', () => {
+			const observer1 = {
+				'bar': 'foo'
+			};
+			const observer2 = {
+				'abc': 'efg'
+			};
+			const property = 'property';
+			const value1 = 'hello';
+			const value2 = 'goodbye';
+
+			observerMap.add(observer1, property);
+			observerMap.setProperty(value1);
+
+			observerMap2.add(observer2, property);
+			observerMap2.setProperty(value2);
+
+			observerMap.merge(observerMap2);
+
+			assert.equal(observerMap._observers.size, 2, 'should have two observers after merge');
+			assert.equal(observerMap._observers.get(observer1), property, 'should have original observer unmodified');
+			assert.equal(observerMap._observers.get(observer2), property, 'should have merged observer added');
+			assert.equal(observer1[property], value1, 'first observer should map to original property');
+			assert.equal(observer2[property], value1, 'second observer should map to new property');
+
+			assert.equal(observerMap2._observers.size, 1, 'observerMap2 should be unaltered after merge');
+		});
+
+		it('should be unaltered after merging map with same entry', () => {
+			const observer1 = {
+				'bar': 'foo'
+			};
+
+			const property = 'property';
+			const value1 = 'hello';
+
+			observerMap.add(observer1, property);
+			observerMap.setProperty(value1);
+
+			observerMap2.add(observer1, property);
+
+			observerMap.merge(observerMap2);
+
+			assert.equal(observerMap._observers.size, 1, 'should have two observers after merge');
+			assert.equal(observerMap._observers.get(observer1), property, 'should have original observer unmodified');
+			assert.equal(observer1[property], value1, 'first observer should map to original property');
+
+			assert.equal(observerMap2._observers.size, 1, 'observerMap2 should be unaltered after merge');
+		});
+
+		it('should merge two large observerMaps', () => {
+			const observer1 = {
+				'bar': 'foo'
+			};
+			const observer2 = {
+				'abc': '123'
+			};
+			const observer3 = {
+				'xyz': '789'
+			};
+			const observer4 = {
+				'name': 'foo'
+			};
+
+			const property = 'property';
+			const link = 'link';
+			const value1 = 'hello';
+			const value2 = 'goodbye';
+
+			observerMap.add(observer1, property);
+			observerMap.add(observer2, link);
+			observerMap.setProperty(value1);
+
+			observerMap2.add(observer3, property);
+			observerMap2.add(observer4, link);
+			observerMap2.setProperty(value2);
+
+			observerMap.merge(observerMap2);
+
+			assert.equal(observerMap._observers.size, 4, 'should have two observers after merge');
+			assert.equal(observerMap._observers.get(observer1), property, 'observer1 should be property');
+			assert.equal(observerMap._observers.get(observer2), link, 'observer2 should be link');
+			assert.equal(observerMap._observers.get(observer3), property, 'observer3 should be property');
+			assert.equal(observerMap._observers.get(observer4), link, 'observer4 should be link');
+			assert.equal(observer1[property], value1, 'observer1 should map to original property');
+			assert.equal(observer2[link], value1, 'observer2 should map to original property');
+			assert.equal(observer3[property], value1, 'observer3 should map to updated');
+			assert.equal(observer4[link], value1, 'observer1 should map to updated property');
+
+			assert.equal(observerMap2._observers.size, 2, 'observerMap2 should be unaltered after merge');
+		});
+
+		it('should merge two observers and apply method', () => {
+			const observer1 = {
+				'bar': 'foo'
+			};
+			const observer2 = {
+				'abc': 'efg'
+			};
+			const property = 'property';
+			const value1 = 'hello';
+			const value2 = 'goodbye';
+			const method = (val) => `${val}${val}`;
+			assert.isFunction(method);
+
+			observerMap.add(observer1, property);
+			observerMap.setProperty(value1);
+
+			observerMap2.add(observer2, property, method);
+			observerMap2.setProperty(value2);
+
+			observerMap.merge(observerMap2);
+
+			assert.equal(observerMap._observers.size, 2, 'should have two observers after merge');
+			assert.equal(observerMap._observers.get(observer1), property, 'should have original observer unmodified');
+			assert.equal(observerMap._observers.get(observer2), property, 'should have merged observer added');
+			assert.equal(observer1[property], value1, 'first observer should map to original property');
+			assert.equal(observer2[property], `${value1}${value1}`, 'second observer should map to new mapped property');
+
+			assert.equal(observerMap2._observers.size, 1, 'observerMap2 should be unaltered after merge');
+		});
+	});
 });


### PR DESCRIPTION
[Story](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?Iteration=%2Fiteration%2F357252967044&Name=&Project=%2Fproject%2F357252966636&Release=u&cpoid=357252966636&detail=%2Fuserstory%2F460347083068&rankScope=%2Fiteration%2F357252967044&rankTo=BOTTOM&typeDef=7362609683)

Method allows for consistent merging of observerMaps and eases testing. Yay.