### PR TITLE
feat: SubEntity and SubEntities observables reflect the siren parsed entity

### DIFF
--- a/state/observable/SirenSubEntities.js
+++ b/state/observable/SirenSubEntities.js
@@ -17,16 +17,15 @@ export class SirenSubEntities extends Observable {
 		this._rel = id;
 		this._entityMap = new Map();
 		this._token = token;
-		this.entities = [];
 	}
 
 	get entities() {
 		return this._observers.value;
 	}
 
-	set entities(entities) {
-		if (this.entities !== entities) {
-			this._observers.setProperty(entities || []);
+	set entities(sirenParsedEntities) {
+		if (this.entities !== sirenParsedEntities) {
+			this._observers.setProperty(sirenParsedEntities || []);
 		}
 	}
 
@@ -38,10 +37,10 @@ export class SirenSubEntities extends Observable {
 		return this._rel;
 	}
 
-	setSirenEntity(sirenEntity) {
-		const subEntities = sirenEntity && sirenEntity.getSubEntitiesByRel(this._rel);
+	setSirenEntity(sirenParsedEntity) {
+		const subEntities = sirenParsedEntity && sirenParsedEntity.getSubEntitiesByRel(this._rel);
 		const entityMap = new Map();
-		const entities = [];
+		const sirenParsedEntities = [];
 
 		// This makes the assumption that the order returned by the collection
 		// matches the prev/next order for each item.
@@ -61,13 +60,13 @@ export class SirenSubEntities extends Observable {
 				subEntity.entity = sirenSubEntity;
 			}
 			entityMap.set(entityID, subEntity);
-			entities.push(subEntity.entity);
+			sirenParsedEntities.push(subEntity.entity);
 		});
 
 		// Clear the old entity map and reset it to the new one
 		this.entityMap.clear();
 		this._entityMap = entityMap;
 
-		this.entities = entities;
+		this.entities = sirenParsedEntities;
 	}
 }

--- a/state/observable/SirenSubEntities.js
+++ b/state/observable/SirenSubEntities.js
@@ -20,7 +20,7 @@ export class SirenSubEntities extends Observable {
 	}
 
 	get entities() {
-		return this._observers.value;
+		return this._observers.value || [];
 	}
 
 	set entities(sirenParsedEntities) {

--- a/state/observable/SirenSubEntities.js
+++ b/state/observable/SirenSubEntities.js
@@ -41,6 +41,7 @@ export class SirenSubEntities extends Observable {
 	setSirenEntity(sirenEntity) {
 		const subEntities = sirenEntity && sirenEntity.getSubEntitiesByRel(this._rel);
 		const entityMap = new Map();
+		const entities = [];
 
 		// This makes the assumption that the order returned by the collection
 		// matches the prev/next order for each item.
@@ -50,29 +51,22 @@ export class SirenSubEntities extends Observable {
 		// and will change based on the individual item update.
 		subEntities.forEach((sirenSubEntity) => {
 			const entityID = getEntityIDFromSirenEntity(sirenSubEntity);
+			let subEntity;
 			// If we already set it up why do it again?
 			if (this.entityMap.has(entityID)) {
-				entityMap.set(entityID, this.entityMap.get(entityID));
-				this.entityMap.delete(entityID);
-				return;
+				subEntity = this.entityMap.get(entityID);
+			} else {
+				// todo: create a facade to make the subEntity easier to work with
+				subEntity = new SirenSubEntity({ id: this.rel, token: this._token });
+				subEntity.entity = sirenSubEntity;
 			}
-
-			const subEntity = new SirenSubEntity({ id: this.rel, token: this._token });
-			// todo: create a facade to make the subEntity easier to work with
-			sirenSubEntity.href = entityID;
-			subEntity.entity = sirenSubEntity;
 			entityMap.set(entityID, subEntity);
-		});
-
-		// These ones are no longer required.
-		this.entityMap.clear();
-
-		this._entityMap = entityMap;
-
-		const entities = [];
-		this.entityMap.forEach((subEntity) => {
 			entities.push(subEntity.entity);
 		});
+
+		// Clear the old entity map and reset it to the new one
+		this.entityMap.clear();
+		this._entityMap = entityMap;
 
 		this.entities = entities;
 	}

--- a/state/observable/SirenSubEntity.js
+++ b/state/observable/SirenSubEntity.js
@@ -3,6 +3,10 @@ import { getEntityIDFromSirenEntity } from './ObserverMap.js';
 import { Observable } from './Observable.js';
 import { shouldAttachToken } from '../token.js';
 
+/**
+ * Observable SirenSubEntity object
+ * Reflects back the siren parsed entity to any observers
+ */
 export class SirenSubEntity extends Observable {
 	constructor({ id, token, state } = {}) {
 		super();
@@ -12,13 +16,13 @@ export class SirenSubEntity extends Observable {
 		this._token = token;
 	}
 
-	get entityID() {
+	get entity() {
 		return this._observers.value;
 	}
 
-	set entityID(entityID) {
-		if (this.entityID !== entityID) {
-			this._observers.setProperty(entityID);
+	set entity(subEntity) {
+		if (this.entity !== subEntity) {
+			this._observers.setProperty(subEntity);
 		}
 	}
 
@@ -73,10 +77,11 @@ export class SirenSubEntity extends Observable {
 	}
 
 	async _setSubEntity(subEntity) {
-		this.entityID = getEntityIDFromSirenEntity(subEntity);
+		const entityId = getEntityIDFromSirenEntity(subEntity);
+		this.entity = subEntity;
 
 		if (this._token) {
-			this._childState = await this.createChildState(this.entityID, shouldAttachToken(this._token.rawToken, subEntity));
+			this._childState = await this.createChildState(entityId, shouldAttachToken(this._token.rawToken, subEntity));
 			this._childState.setSirenEntity(subEntity);
 			this._routes.forEach((route, observer) => {
 				this._childState.addObservables(observer, route);

--- a/state/observable/SirenSubEntity.js
+++ b/state/observable/SirenSubEntity.js
@@ -20,8 +20,13 @@ export class SirenSubEntity extends Observable {
 		return this._observers.value;
 	}
 
+	/**
+	 * @param {Entity} subEntity siren parsed entity to set to
+	 */
 	set entity(subEntity) {
 		if (this.entity !== subEntity) {
+			// todo: remove this when we have the facade for subEntity
+			subEntity.href = getEntityIDFromSirenEntity(subEntity);
 			this._observers.setProperty(subEntity);
 		}
 	}

--- a/state/observable/SirenSubEntity.js
+++ b/state/observable/SirenSubEntity.js
@@ -21,7 +21,7 @@ export class SirenSubEntity extends Observable {
 	}
 
 	/**
-	 * @param {Entity} subEntity siren parsed entity to set to
+	 * @param {Entity} subEntity siren-parser Entity to set to
 	 */
 	set entity(subEntity) {
 		if (this.entity !== subEntity) {

--- a/test/observable/sirenSubEntities.test.js
+++ b/test/observable/sirenSubEntities.test.js
@@ -11,9 +11,9 @@ describe('subEntities basic methods', () => {
 		assert.isUndefined(obj._state, 'subEntities state initialized by empty object');
 		assert.isUndefined(obj.rel, 'subEntities rel initialized by empty object');
 		assert.isUndefined(obj._token, 'subEntities token initialized by empty object');
-		assert.instanceOf(obj.childSubEntities, Map, 'subEntities children should be a map');
-		assert.isArray(obj.entityIDs, 'subEntities entityIDs should be empty list');
-		assert.isEmpty(obj.entityIDs, 'subEntites enitityIDS should start empty');
+		assert.instanceOf(obj.entityMap, Map, 'subEntities children should be a map');
+		assert.isArray(obj.entities, 'subEntities entities should be empty list');
+		assert.isEmpty(obj.entities, 'subEntites enitityIDS should start empty');
 	});
 
 	it('sirenSubEntites constructed from non-empty object', () => {
@@ -22,9 +22,9 @@ describe('subEntities basic methods', () => {
 		assert.equal(obj._state, 'hello', 'subEntities state should be initialized');
 		assert.equal(obj.rel, 'abc', 'subEntities rel should be initialized');
 		assert.equal(obj._token, '1234', 'subEntities token should be initialized');
-		assert.instanceOf(obj.childSubEntities, Map, 'subEntities children should be a map');
-		assert.isArray(obj.entityIDs, 'subEntities entityIDs should be empty list');
-		assert.isEmpty(obj.entityIDs, 'subEntites enitityIDS should start empty');
+		assert.instanceOf(obj.entityMap, Map, 'subEntities children should be a map');
+		assert.isArray(obj.entities, 'subEntities entities should be empty list');
+		assert.isEmpty(obj.entities, 'subEntites enitityIDS should start empty');
 	});
 });
 
@@ -36,8 +36,8 @@ describe('sirenSubEntities set sirenEntity', () =>  {
 
 		subentites.setSirenEntity(entity);
 
-		assert.equal(subentites.childSubEntities.size, 0, 'SirenSubEntities should have 0 children');
-		assert.deepEqual(subentites.entityIDs, [], 'SirenSubEntities should have 0 entityIDs');
+		assert.equal(subentites.entityMap.size, 0, 'SirenSubEntities should have 0 children');
+		assert.deepEqual(subentites.entities, [], 'SirenSubEntities should have 0 entities');
 	});
 
 	it('entity with one matching id has been added as subentity', () => {
@@ -46,11 +46,11 @@ describe('sirenSubEntities set sirenEntity', () =>  {
 
 		subentites.setSirenEntity(entity);
 
-		assert.equal(subentites.childSubEntities.size, 1, 'SirenSubEntities should have 1 child');
-		assert.isTrue(subentites.childSubEntities.has('www.abc.com'), 'SirenSubEntities should have child stored');
-		const addedSubentity = subentites.childSubEntities.get('www.abc.com');
+		assert.equal(subentites.entityMap.size, 1, 'SirenSubEntities should have 1 child');
+		assert.isTrue(subentites.entityMap.has('www.abc.com'), 'SirenSubEntities should have child stored');
+		const addedSubentity = subentites.entityMap.get('www.abc.com');
 		assert.instanceOf(addedSubentity, SirenSubEntity, 'SirenSubEntities child should be a SirenSubEntity');
-		assert.deepEqual(subentites.entityIDs, ['www.abc.com'], 'SirenSubEntities entityIDs should store one href');
+		assert.deepEqual(subentites.entities, entity.entities, 'SirenSubEntities entities should store one href');
 	});
 
 	it('entity with two matching ids has been added as subentity', () => {
@@ -59,10 +59,10 @@ describe('sirenSubEntities set sirenEntity', () =>  {
 
 		subentites.setSirenEntity(entity);
 
-		assert.equal(subentites.childSubEntities.size, 2, 'SirenSubEntities should have 2 children');
-		assert.isTrue(subentites.childSubEntities.has('www.def.com'), 'SirenSubEntities should store first child');
-		assert.isTrue(subentites.childSubEntities.has('www.xyz.com'), 'SirenSubEntities should store second child');
-		assert.deepEqual(subentites.entityIDs, ['www.def.com', 'www.xyz.com'], 'SirenSubEntities entityIDs should store two hrefs');
+		assert.equal(subentites.entityMap.size, 2, 'SirenSubEntities should have 2 children');
+		assert.isTrue(subentites.entityMap.has('www.def.com'), 'SirenSubEntities should store first child');
+		assert.isTrue(subentites.entityMap.has('www.xyz.com'), 'SirenSubEntities should store second child');
+		assert.deepEqual(subentites.entities, entity.entities, 'SirenSubEntities entities should store two hrefs');
 	});
 
 	it('entity with two matching ids overwritten with one id', () => {
@@ -73,8 +73,8 @@ describe('sirenSubEntities set sirenEntity', () =>  {
 		subentites.setSirenEntity(entity1);
 		subentites.setSirenEntity(entity2);
 
-		assert.equal(subentites.childSubEntities.size, 1, 'SirenSubEntities should have 1 child');
-		assert.isTrue(subentites.childSubEntities.has('www.abc.com'), 'SirenSubEntities should have child stored');
-		assert.deepEqual(subentites.entityIDs, ['www.abc.com'], 'SirenSubEntities entityIDs should store one href');
+		assert.equal(subentites.entityMap.size, 1, 'SirenSubEntities should have 1 child');
+		assert.isTrue(subentites.entityMap.has('www.abc.com'), 'SirenSubEntities should have child stored');
+		assert.deepEqual(subentites.entities, entity2.entities, 'SirenSubEntities entities should store one href');
 	});
 });

--- a/test/observable/sirenSubEntities.test.js
+++ b/test/observable/sirenSubEntities.test.js
@@ -12,7 +12,7 @@ describe('subEntities basic methods', () => {
 		assert.isUndefined(obj.rel, 'subEntities rel initialized by empty object');
 		assert.isUndefined(obj._token, 'subEntities token initialized by empty object');
 		assert.instanceOf(obj.entityMap, Map, 'subEntities children should be a map');
-		assert.isArray(obj.entities, 'subEntities entities should be empty list');
+		assert.isArray(obj.entities, 'subEntities entities should be array type');
 		assert.isEmpty(obj.entities, 'subEntities list should start empty');
 	});
 
@@ -23,7 +23,7 @@ describe('subEntities basic methods', () => {
 		assert.equal(obj.rel, 'abc', 'subEntities rel should be initialized');
 		assert.equal(obj._token, '1234', 'subEntities token should be initialized');
 		assert.instanceOf(obj.entityMap, Map, 'subEntities children should be a map');
-		assert.isArray(obj.entities, 'subEntities entities should be empty list');
+		assert.isArray(obj.entities, 'subEntities entities should be an array type');
 		assert.isEmpty(obj.entities, 'subEntities list should start empty');
 	});
 });

--- a/test/observable/sirenSubEntities.test.js
+++ b/test/observable/sirenSubEntities.test.js
@@ -13,7 +13,7 @@ describe('subEntities basic methods', () => {
 		assert.isUndefined(obj._token, 'subEntities token initialized by empty object');
 		assert.instanceOf(obj.entityMap, Map, 'subEntities children should be a map');
 		assert.isArray(obj.entities, 'subEntities entities should be empty list');
-		assert.isEmpty(obj.entities, 'subEntites enitityIDS should start empty');
+		assert.isEmpty(obj.entities, 'subEntities list should start empty');
 	});
 
 	it('sirenSubEntites constructed from non-empty object', () => {
@@ -24,7 +24,7 @@ describe('subEntities basic methods', () => {
 		assert.equal(obj._token, '1234', 'subEntities token should be initialized');
 		assert.instanceOf(obj.entityMap, Map, 'subEntities children should be a map');
 		assert.isArray(obj.entities, 'subEntities entities should be empty list');
-		assert.isEmpty(obj.entities, 'subEntites enitityIDS should start empty');
+		assert.isEmpty(obj.entities, 'subEntities list should start empty');
 	});
 });
 
@@ -50,7 +50,7 @@ describe('sirenSubEntities set sirenEntity', () =>  {
 		assert.isTrue(subentites.entityMap.has('www.abc.com'), 'SirenSubEntities should have child stored');
 		const addedSubentity = subentites.entityMap.get('www.abc.com');
 		assert.instanceOf(addedSubentity, SirenSubEntity, 'SirenSubEntities child should be a SirenSubEntity');
-		assert.deepEqual(subentites.entities, entity.entities, 'SirenSubEntities entities should store one href');
+		assert.deepEqual(subentites.entities, entity.entities, 'SirenSubEntities entities should store one entity');
 	});
 
 	it('entity with two matching ids has been added as subentity', () => {
@@ -62,7 +62,7 @@ describe('sirenSubEntities set sirenEntity', () =>  {
 		assert.equal(subentites.entityMap.size, 2, 'SirenSubEntities should have 2 children');
 		assert.isTrue(subentites.entityMap.has('www.def.com'), 'SirenSubEntities should store first child');
 		assert.isTrue(subentites.entityMap.has('www.xyz.com'), 'SirenSubEntities should store second child');
-		assert.deepEqual(subentites.entities, entity.entities, 'SirenSubEntities entities should store two hrefs');
+		assert.deepEqual(subentites.entities, entity.entities, 'SirenSubEntities entities should store two entities');
 	});
 
 	it('entity with two matching ids overwritten with one id', () => {
@@ -75,6 +75,6 @@ describe('sirenSubEntities set sirenEntity', () =>  {
 
 		assert.equal(subentites.entityMap.size, 1, 'SirenSubEntities should have 1 child');
 		assert.isTrue(subentites.entityMap.has('www.abc.com'), 'SirenSubEntities should have child stored');
-		assert.deepEqual(subentites.entities, entity2.entities, 'SirenSubEntities entities should store one href');
+		assert.deepEqual(subentites.entities, entity2.entities, 'SirenSubEntities entities should store one entity');
 	});
 });

--- a/test/observable/sirenSubEntity.test.js
+++ b/test/observable/sirenSubEntity.test.js
@@ -36,7 +36,7 @@ describe('sirenSubEntity method tests', () => {
 
 		assert.equal(sub.rel, 'foo', 'subEntity rel field initialized incorrectly');
 		assert.equal(sub._token, 'bar', 'subEntity token field initialized incorrectly');
-		assert.deepEqual(sub.entity, { href: 'baz' }, 'subEntity rel field set incorrectly');
+		assert.deepEqual(sub.entity, { href: 'baz' }, 'subEntity entity should be set correctly');
 		assert.instanceOf(sub._routes, Map, 'routes should be a Map');
 		assert.equal(sub._routes.size, 0, 'subEntity routes should be empty when constructed');
 	});

--- a/test/observable/sirenSubEntity.test.js
+++ b/test/observable/sirenSubEntity.test.js
@@ -30,13 +30,13 @@ describe('sirenSubEntity method tests', () => {
 		assert.equal(sub._routes.size, 0, 'subEntity routes should be empty when constructed');
 	});
 
-	it('subEntity constructed from appropriate object and entityID set', () => {
+	it('subEntity constructed from appropriate object and entity set', () => {
 		const sub = new SirenSubEntity({ id: 'foo', token: 'bar' });
-		sub.entityID = 'baz';
+		sub.entity = { href: 'baz' };
 
 		assert.equal(sub.rel, 'foo', 'subEntity rel field initialized incorrectly');
 		assert.equal(sub._token, 'bar', 'subEntity token field initialized incorrectly');
-		assert.equal(sub.entityID, 'baz', 'subEntity rel field set incorrectly');
+		assert.deepEqual(sub.entity, { href: 'baz' }, 'subEntity rel field set incorrectly');
 		assert.instanceOf(sub._routes, Map, 'routes should be a Map');
 		assert.equal(sub._routes.size, 0, 'subEntity routes should be empty when constructed');
 	});


### PR DESCRIPTION
## Context
[US122956](https://rally1.rallydev.com/#/detail/userstory/460074259704?fdp=true)
The `observableTypes.subEntity` and`observableTypes.subEntities` now reflect a value that is an object. For now, this is the siren entity object parsed from `siren-parser`. This gives the developer creating a component access to the subEntities' links, properties, etc. In the future, this will be a friendly facade that will be easy to interact with when building foundation components.

### Changes
Before, the value of a subEntity and the subEntities array reflected only the `href`. This was problematic for both selfless entities and was also non-intuitive to work with and read.

Subentities are still indexed by their `self` links, but this will be altered in the future to support selfless entities.

### Example of new usage
```js
class CustomComponent  extends HypermediaStateMixin(LitElement)  {
    static get properties() {
        return {
            items: { type: Array, observable: observableTypes.subEntities, rel: rels.item, route: [{observable: observableTypes.link, rel: rels.collection}] }
		};
    }

    render() {
         return html`
              <d2l-list>${repeat(this.items, item => item.href, item => html`
                    <d2l-activity-list-item href="${item.href}" .token="${this.token}" draggable key="${item.properties.id}"></d2l-activity-list-item>
               `)}
	      </d2l-list>
        `;
    }
}
```

## Quality
- Tested with local BSI on `polarisdev` with this branch: https://github.com/BrightspaceHypermediaComponents/foundation-components/tree/zina/subentity-objects
- Updated unit tests to reflect the change