### PR TITLE
fix: We shouldn't allow HypermediaState to be exported

### DIFF
--- a/state/HypermediaState.js
+++ b/state/HypermediaState.js
@@ -15,10 +15,9 @@ const store = window.D2L.Foundation.StateStore;
 
 /**
  *
- * @export
  * @class HypermediaState
  */
-export class HypermediaState extends Fetchable(Object) {
+class HypermediaState extends Fetchable(Object) {
 	constructor(entityID, token) {
 		super(entityID, token);
 

--- a/test/siren-observables.test.js
+++ b/test/siren-observables.test.js
@@ -1,6 +1,5 @@
 import { assert, expect }  from '@open-wc/testing';
 import { observableTypes as ot, sirenObservableFactory, sirenObserverDefinedProperty } from '../state/observable/sirenObservableFactory.js';
-import { HypermediaState } from '../state/HypermediaState.js';
 import { SirenAction } from '../state/observable/SirenAction.js';
 import { SirenClasses } from '../state/observable/SirenClasses.js';
 import { SirenEntity } from '../state/observable/SirenEntity.js';
@@ -8,6 +7,7 @@ import { SirenLink } from '../state/observable/SirenLink.js';
 import { SirenProperty } from '../state/observable/SirenProperty.js';
 import { SirenSubEntities } from '../state/observable/SirenSubEntities.js';
 import { SirenSubEntity } from '../state/observable/SirenSubEntity.js';
+import { stateFactory } from '../state/HypermediaState.js';
 
 const orgHref = 'https://api.brightspace.com/rels/organization';
 
@@ -234,7 +234,7 @@ describe('calling sirenObserverDefinedProperty with observable objects', () => {
 
 	it('property created for sirenLink with a HypermediaState', () => {
 		const obj = { type: String, observable: ot.link, rel: orgHref };
-		const state = new HypermediaState(orgHref, 21312);
+		const state = stateFactory(orgHref, 21312);
 		const res = sirenObserverDefinedProperty(obj, state);
 
 		assert.equal(res.type, ot.link, 'property link was set incorrectly');


### PR DESCRIPTION
Title says it all. Fixed the one set of tests that required it.