### PR TITLE
Update fetch to be more consistent in calls.

### DIFF
--- a/state/fetch.js
+++ b/state/fetch.js
@@ -14,11 +14,15 @@ export function fetch(fetchable, bypassCache = false) {
 
 	performServerFetch(fetchable, bypassCache);
 
-	responsePromise
-		.then(json => fetchable.onServerResponse(json))
-		.catch(error => fetchable.onServerResponse(null, error));
-
-	return responsePromise;
+	return responsePromise
+		.then(json => {
+			fetchable.onServerResponse(json);
+			return json;
+		})
+		.catch(error => {
+			fetchable.onServerResponse(null, error);
+			throw error;
+		});
 }
 
 async function performServerFetch(fetchable, bypassCache) {


### PR DESCRIPTION
Basically, what we had before if you `await fetch` the call to onServerResponse may run before or may run after.. This will probably cause a lot of headaches so I've changed it so the promise returned isn't the same promise as `fetchable.fetchStatus` however it should resolve as if it was the same one. This time you can be assured that `onServerResponse` has run and was successful.

This also has the added benefits of people being able to catch errors from `onServerResponse` when calling fetch.

I ran this code through my tests in my other branch. Given the change is complex enough. I decided to switch it off to it's own branch. Also, it seems like it could help the other tests in progress so it will hopefully be merged faster than my test one.