### PR TITLE
Added SirenFacade and unit tests

### DIFF
--- a/state/observable/SirenFacade.js
+++ b/state/observable/SirenFacade.js
@@ -1,0 +1,36 @@
+import { getEntityIDFromSirenEntity } from './ObserverMap.js';
+/**
+ * A class to transform parsed siren entities into easy to use
+ * objects to be reflected and worked with in foundation components.
+ */
+export class SirenFacade {
+	/**
+	 * Creates the facade from a parsed entity
+	 * @param {Entity} sirenParsedEntity - The raw entity as it has been parsed by SirenParser
+	 * @param {Boolean} verbose - Whether to return more or less information
+	 */
+	constructor(sirenParsedEntity, verbose = false) {
+		if (!sirenParsedEntity) return;
+
+		this.href = getEntityIDFromSirenEntity(sirenParsedEntity) || undefined;
+		this.class = sirenParsedEntity.class || [];
+		this.links = sirenParsedEntity.links || [];
+		// todo: We should figure out how we want to do actions - this is just a list of names
+		this.actions = sirenParsedEntity.actions ? sirenParsedEntity.actions.map(x => x.name) : [];
+		// todo: sub entities only go one level currently
+		this.entities = sirenParsedEntity.entities ? sirenParsedEntity.entities.map(x => new SirenFacade(x)) : [];
+		this.properties = sirenParsedEntity.properties || {};
+		if (verbose) {
+			this.rawSirenParsedEntity = sirenParsedEntity;
+		}
+	}
+
+	/**
+	 * Checks if the class name exists on the entity or not
+	 * @param {String} className - Class name to check
+	 * @returns {Boolean}
+	 */
+	hasClass(className) {
+		return !!(this.class.length && this.class.includes(className));
+	}
+}

--- a/state/observable/SirenFacade.js
+++ b/state/observable/SirenFacade.js
@@ -18,7 +18,7 @@ export class SirenFacade {
 		// todo: We should figure out how we want to do actions - this is just a list of names
 		this.actions = sirenParsedEntity.actions ? sirenParsedEntity.actions.map(x => x.name) : [];
 		// todo: sub entities only go one level currently
-		this.entities = sirenParsedEntity.entities ? sirenParsedEntity.entities.map(x => new SirenFacade(x)) : [];
+		this.entities = sirenParsedEntity.entities ? sirenParsedEntity.entities.map(x => new SirenFacade(x, verbose)) : [];
 		this.properties = sirenParsedEntity.properties || {};
 		if (verbose) {
 			this.rawSirenParsedEntity = sirenParsedEntity;

--- a/test/data/observable/entities.js
+++ b/test/data/observable/entities.js
@@ -1,66 +1,66 @@
 export const subEntitiesTests = { fooEntity:`{
-  "entities": [{"rel": ["foo"], "href": "www.abc.com"}],
-  "links": [{
-	"rel": ["self"],
-	"href": "http://example.com"
-  }],
-  "href": "hello"
+	"entities": [{"rel": ["foo"], "href": "www.abc.com"}],
+	"links": [{
+		"rel": ["self"],
+		"href": "http://example.com"
+	}],
+	"href": "hello"
 }`,
 barEntity: `{
-  "entities": [{"rel": ["bar"], "href": "www.abc.com"}],
-  "links": [{
-	"rel": ["self"],
-	"href": "http://example.com"
-  }],
-  "href": "hello"
+	"entities": [{"rel": ["bar"], "href": "www.abc.com"}],
+	"links": [{
+		"rel": ["self"],
+		"href": "http://example.com"
+	}],
+	"href": "hello"
 }`,
 multipleSubEntities: `{
 	"entities": [{"rel": ["foo"], "href": "www.def.com"},{"rel": ["foo"], "href": "www.xyz.com"}],
 	"links": [{
-	  "rel": ["self"],
-	  "href": "http://example.com"
+		"rel": ["self"],
+		"href": "http://example.com"
 	}],
 	"href": "hello"
-  }`
+	}`
 };
 
 export const linkTests = { fooRel: `{
 	"links": [{
-	  "rel": ["foo"],
-	  "href": "http://example.com"
+		"rel": ["foo"],
+		"href": "http://example.com"
 	}]
-  }`, barRel: `{
-	"links": [{
-	  "rel": ["bar"],
-	  "href": "http://example.com"
-	}]
-  }`
+	}`, barRel: `{
+		"links": [{
+			"rel": ["bar"],
+			"href": "http://example.com"
+		}]
+	}`
 };
 
 export const subEntityTests = { entityWithHref: `{
 	"entities": [{
-        "rel": ["foo"],
-        "links": [{
-            "rel": ["self"],
-            "href": "www.subentity.com"
+		"rel": ["foo"],
+		"links": [{
+			"rel": ["self"],
+			"href": "www.subentity.com"
 		}],
 		"href": "www.foo.com"
-    }]
-  }`, entityWithoutHref:`{
+	}]
+	}`, entityWithoutHref:`{
 	"entities": [{
-        "rel": ["foo"],
-        "links": [{
-            "rel": ["self"],
-            "href": "www.subentity.com"
+		"rel": ["foo"],
+		"links": [{
+			"rel": ["self"],
+			"href": "www.subentity.com"
 		}]
-    }]
-  }`, barEntity: `{
+	}]
+	}`, barEntity: `{
 	"entities": [{
-        "rel": ["bar"],
-        "links": [{
-            "rel": ["self"],
-            "href": "www.subentity.com"
+		"rel": ["bar"],
+		"links": [{
+			"rel": ["self"],
+			"href": "www.subentity.com"
 		}]
-    }]
-  }`
+	}]
+	}`
 };

--- a/test/observable/sirenFacade.test.js
+++ b/test/observable/sirenFacade.test.js
@@ -111,5 +111,17 @@ describe('SirenFacade', () => {
 			expect(facade.rawSirenParsedEntity).to.exist;
 			expect(facade.rawSirenParsedEntity._linksByRel.linkedThing).to.be.lengthOf(1);
 		});
+
+		it('has verbose sub-entity', async() => {
+			const entity = await SirenParse({
+				'entities': [
+					{ 'rel': ['item'], 'links': [{ 'rel': ['linkedThing'], 'href': 'http://linked-thing' }] }
+				]
+			});
+			const facade = new SirenFacade(entity, true);
+			expect(facade.entities).to.have.lengthOf(1);
+			expect(facade.entities[0].rawSirenParsedEntity).to.exist;
+			expect(facade.entities[0].rawSirenParsedEntity._linksByRel.linkedThing).to.be.lengthOf(1);
+		});
 	});
 });

--- a/test/observable/sirenFacade.test.js
+++ b/test/observable/sirenFacade.test.js
@@ -1,0 +1,115 @@
+import { expect } from '@open-wc/testing';
+import { SirenFacade } from '../../state/observable/SirenFacade.js';
+import { default as SirenParse } from 'siren-parser';
+
+describe('SirenFacade', () => {
+	it('constructs with no arguments', () => {
+		const facade = new SirenFacade();
+		expect(facade).to.be.empty;
+	});
+
+	it('constructs with empty object', () => {
+		const facade = new SirenFacade({});
+		expect(facade.href).to.be.undefined;
+		expect(facade.class).to.be.empty;
+		expect(facade.entities).to.be.empty;
+		expect(facade.links).to.be.empty;
+		expect(facade.properties).to.be.empty;
+		expect(facade.rawSirenParsedEntity).to.be.undefined;
+		expect(facade.actions).to.be.empty;
+	});
+
+	describe('SirenParser integration', () => {
+		it('creates a facade from an object with no self link', async() => {
+			const entity = await SirenParse({
+				'links': [{ 'rel':['some-rel'], 'href': 'RandomLink' }]
+			});
+			const facade = new SirenFacade(entity);
+			expect(facade.href).to.be.undefined;
+			expect(facade.links).to.have.lengthOf(1);
+		});
+
+		it('creates a facade from an object with a self link', async() => {
+			const entity = await SirenParse({
+				'links': [{ 'rel':['self'], 'href': 'selfLink' }]
+			});
+			const facade = new SirenFacade(entity);
+			expect(facade.href).to.be.equal('selfLink');
+			expect(facade.links).to.have.lengthOf(1);
+		});
+
+		it('has classes on the facade that can be accessed with hasClass', async() => {
+			const entity = await SirenParse({
+				'class': ['class-one', 'class-two']
+			});
+			const facade = new SirenFacade(entity);
+			expect(facade.class).to.be.lengthOf(2);
+			expect(facade.hasClass('class-one')).to.be.true;
+			expect(facade.hasClass('class-two')).to.be.true;
+			expect(facade.hasClass('non-existent')).to.be.false;
+		});
+
+		it('has a properties object even when there are no properties', async() => {
+			const entity = await SirenParse({});
+			const facade = new SirenFacade(entity);
+			expect(facade.properties).to.not.be.undefined;
+			expect(facade.properties.someProperty).to.be.undefined;
+		});
+
+		it('has properties set correctly when they exist', async() => {
+			const entity = await SirenParse({
+				'properties': { 'name': 'leeroy', 'answer-to-life': 'not 2020' }
+			});
+			const facade = new SirenFacade(entity);
+			expect(facade.properties.name).to.equal('leeroy');
+			expect(facade.properties['answer-to-life']).to.equal('not 2020');
+		});
+
+		it('has sub-entities that are also SirenFacades', async() => {
+			const entity = await SirenParse({
+				'entities': [
+					{ 'rel': ['item'] },
+					{ 'rel': ['item'] },
+					{ 'rel': ['with-self-link'], 'links': [{ 'rel': ['self'], 'href': 'selfLink' }] }
+				]
+			});
+			const facade = new SirenFacade(entity);
+			expect(facade.entities).to.have.lengthOf(3);
+			expect(facade.entities[0]).to.be.instanceof(SirenFacade);
+			expect(facade.entities[2].href).to.be.equal('selfLink');
+		});
+
+		it('has actions that are just the names', async() => {
+			const entity = await SirenParse({
+				'actions': [
+					{ 'href': 'http://action-one', 'name': 'action-one', 'method': 'GET' },
+					{ 'href': 'http://action-two', 'name': 'action-with-fields', 'method': 'PATCH', 'fields': [
+						{ 'type': 'text', 'name': 'aTextField' }, { 'type': 'text', 'name': 'anotherField' }
+					] }
+				]
+			});
+			const facade = new SirenFacade(entity);
+			expect(facade.actions).to.have.lengthOf(2);
+			expect(facade.actions[1].fields).to.be.undefined;
+			expect(facade.actions[0]).to.equal('action-one');
+			expect(facade.actions[1]).to.equal('action-with-fields');
+		});
+
+		it('does not give the raw version without verbose mode', async() => {
+			const entity = await SirenParse({
+				'links': [{ 'rel': ['self'], 'href': 'selfLink' }]
+			});
+			const facade = new SirenFacade(entity);
+			expect(facade.rawSirenParsedEntity).to.be.undefined;
+		});
+
+		it('has the raw entity in verbose mode', async() => {
+			const entity = await SirenParse({
+				'links': [{ 'rel': ['linkedThing'], 'href': 'http://linked-thing' }]
+			});
+			const facade = new SirenFacade(entity, true);
+			expect(facade.rawSirenParsedEntity).to.exist;
+			expect(facade.rawSirenParsedEntity._linksByRel.linkedThing).to.be.lengthOf(1);
+		});
+	});
+});


### PR DESCRIPTION
## Context
[US123074](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fuserstory%2F461413871352&fdp=true?fdp=true)

Introduces the `SirenFacade` object, a class designed to be used for reflecting observable Siren entities to components without attaching extraneous information to them. This is the first iteration and has notable items intentionally missing from it.

- Introduces the class, but existing functionality is unchanged. Coming in next PR
- Actions returns just a list of the names of each action. We are still deciding how we want to handle actions attached to subEntities

## Quality
- new unit tests added, which are modelled after styles I liked from both @tenbradley and @AKobets work
  - side note that I think Alex is right and we should start keeping mock data directly in the tests. I find it easier to read.
- coverage for new file is 100%