### PR TITLE
test: Fixing not flaky test

### DIFF
--- a/state/HypermediaState.js
+++ b/state/HypermediaState.js
@@ -39,6 +39,18 @@ class HypermediaState extends Fetchable(Object) {
 		});
 	}
 
+	/**
+	 * Hook for this fetch and all children state fetches to complete
+	 * This does not go further than a single nested state currently because state links can be cyclical
+	 * @returns {Promise} Resolves when this fetch and its linked states are all complete
+	 */
+	get allFetchesComplete() {
+		return (async() => {
+			await this.fetchStatus.complete;
+			await Promise.all(this._childStates().map(state => state.fetchStatus.complete));
+		})();
+	}
+
 	createChildState(entityID, token) {
 		token = token === undefined ? this.token.rawToken : token;
 		return stateFactory(entityID, token);

--- a/test/state/HypermediaState.test.js
+++ b/test/state/HypermediaState.test.js
@@ -147,8 +147,11 @@ describe('HypermediaState class', () => {
 
 			await fetch(state);
 
-			await wait(() => mock.called(entityHref));
-			await wait(() => mock.called(linkedHref));
+			await state.fetchStatus.complete;
+			await Promise.all(state._childStates().map(childState => childState.fetchStatus.complete));
+
+			assert.isTrue(mock.called(entityHref));
+			assert.isTrue(mock.called(linkedHref));
 			assert.deepEqual(observer, {
 				mainEntityClass: ['main-entity-class'],
 				linkedEntityProperty: 'linked-entity-name'

--- a/test/state/HypermediaState.test.js
+++ b/test/state/HypermediaState.test.js
@@ -146,9 +146,7 @@ describe('HypermediaState class', () => {
 			state.addObservables(observer, observable);
 
 			await fetch(state);
-
-			await state.fetchStatus.complete;
-			await Promise.all(state._childStates().map(childState => childState.fetchStatus.complete));
+			await state.allFetchesComplete;
 
 			assert.isTrue(mock.called(entityHref));
 			assert.isTrue(mock.called(linkedHref));


### PR DESCRIPTION
Fixes issue #53 

Wait for the `fetchStatus` on the relevant states instead of for the `mock` to be called.