### PR TITLE
feat: Implement SirenFacade for relevant Observable types

### DIFF
--- a/state/observable/SirenFacade.js
+++ b/state/observable/SirenFacade.js
@@ -13,6 +13,7 @@ export class SirenFacade {
 		if (!sirenParsedEntity) return;
 
 		this.href = getEntityIDFromSirenEntity(sirenParsedEntity) || undefined;
+		this.rel = sirenParsedEntity.rel || [];
 		this.class = sirenParsedEntity.class || [];
 		this.links = sirenParsedEntity.links || [];
 		// todo: We should figure out how we want to do actions - this is just a list of names

--- a/state/observable/SirenSubEntities.js
+++ b/state/observable/SirenSubEntities.js
@@ -7,8 +7,9 @@ import { SirenSubEntity } from './SirenSubEntity.js';
  * Reflects back an array of SirenFacades to any observers
  */
 export class SirenSubEntities extends Observable {
-	static definedProperty({ token }) {
-		return { token };
+
+	static definedProperty({ token, verbose }) {
+		return { token, verbose };
 	}
 
 	constructor({ id, token, state, verbose }) {
@@ -20,6 +21,9 @@ export class SirenSubEntities extends Observable {
 		this._verbose = verbose;
 	}
 
+	/**
+	 * @return { Array<SirenFacade> }
+	 */
 	get entities() {
 		return this._observers.value || [];
 	}

--- a/state/observable/SirenSubEntities.js
+++ b/state/observable/SirenSubEntities.js
@@ -4,28 +4,32 @@ import { SirenSubEntity } from './SirenSubEntity.js';
 
 /**
  * Observable SirenSubEntities
- * Reflects back an array of parsed siren entities to any observers
+ * Reflects back an array of SirenFacades to any observers
  */
 export class SirenSubEntities extends Observable {
 	static definedProperty({ token }) {
 		return { token };
 	}
 
-	constructor({ id, token, state }) {
+	constructor({ id, token, state, verbose }) {
 		super();
 		this._state = state;
 		this._rel = id;
 		this._entityMap = new Map();
 		this._token = token;
+		this._verbose = verbose;
 	}
 
 	get entities() {
 		return this._observers.value || [];
 	}
 
-	set entities(sirenParsedEntities) {
-		if (this.entities !== sirenParsedEntities) {
-			this._observers.setProperty(sirenParsedEntities || []);
+	/**
+	 * @param { Array<SirenFacade> } sirenFacades - List of SirenFacade objects
+	 */
+	set entities(sirenFacades) {
+		if (this.entities !== sirenFacades) {
+			this._observers.setProperty(sirenFacades || []);
 		}
 	}
 
@@ -40,7 +44,7 @@ export class SirenSubEntities extends Observable {
 	setSirenEntity(sirenParsedEntity) {
 		const subEntities = sirenParsedEntity && sirenParsedEntity.getSubEntitiesByRel(this._rel);
 		const entityMap = new Map();
-		const sirenParsedEntities = [];
+		const sirenFacades = [];
 
 		// This makes the assumption that the order returned by the collection
 		// matches the prev/next order for each item.
@@ -55,18 +59,17 @@ export class SirenSubEntities extends Observable {
 			if (this.entityMap.has(entityID)) {
 				subEntity = this.entityMap.get(entityID);
 			} else {
-				// todo: create a facade to make the subEntity easier to work with
-				subEntity = new SirenSubEntity({ id: this.rel, token: this._token });
+				subEntity = new SirenSubEntity({ id: this.rel, token: this._token, verbose: this._verbose });
 				subEntity.entity = sirenSubEntity;
 			}
 			entityMap.set(entityID, subEntity);
-			sirenParsedEntities.push(subEntity.entity);
+			sirenFacades.push(subEntity.entity);
 		});
 
 		// Clear the old entity map and reset it to the new one
 		this.entityMap.clear();
 		this._entityMap = entityMap;
 
-		this.entities = sirenParsedEntities;
+		this.entities = sirenFacades;
 	}
 }

--- a/state/observable/SirenSubEntity.js
+++ b/state/observable/SirenSubEntity.js
@@ -10,6 +10,11 @@ import { SirenFacade } from './SirenFacade.js';
  * Reflects back a SirenFacade to any observers
  */
 export class SirenSubEntity extends Routable(Observable) {
+
+	static definedProperty({ verbose }) {
+		return { verbose };
+	}
+
 	constructor({ id, token, state, verbose } = {}) {
 		super({});
 		this._state = state;

--- a/state/observable/SirenSubEntity.js
+++ b/state/observable/SirenSubEntity.js
@@ -3,17 +3,19 @@ import { getEntityIDFromSirenEntity } from './ObserverMap.js';
 import { Observable } from './Observable.js';
 import { Routable } from './Routable.js';
 import { shouldAttachToken } from '../token.js';
+import { SirenFacade } from './SirenFacade.js';
 
 /**
  * Observable SirenSubEntity object
- * Reflects back the siren parsed entity to any observers
+ * Reflects back a SirenFacade to any observers
  */
 export class SirenSubEntity extends Routable(Observable) {
-	constructor({ id, token, state } = {}) {
+	constructor({ id, token, state, verbose } = {}) {
 		super({});
 		this._state = state;
 		this._rel = id;
 		this._token = token;
+		this._verbose = verbose;
 	}
 
 	get entity() {
@@ -21,13 +23,14 @@ export class SirenSubEntity extends Routable(Observable) {
 	}
 
 	/**
-	 * @param {Entity} subEntity siren-parser Entity to set to
+	 * Mutates a given siren-parser Entity object to a SirenFacade before setting
+	 * the observed property
+	 * @param {Entity} subEntity - the siren-parser entity to set
 	 */
 	set entity(subEntity) {
-		if (this.entity !== subEntity) {
-			// todo: remove this when we have the facade for subEntity
-			subEntity.href = getEntityIDFromSirenEntity(subEntity);
-			this._observers.setProperty(subEntity);
+		const facade = new SirenFacade(subEntity, this._verbose);
+		if (this.entity !== facade) {
+			this._observers.setProperty(facade);
 		}
 	}
 
@@ -36,11 +39,11 @@ export class SirenSubEntity extends Routable(Observable) {
 	}
 
 	setSirenEntity(sirenEntity, SubEntityCollectionMap) {
-		const subEntity = sirenEntity && sirenEntity.hasSubEntityByRel(this._rel) && sirenEntity.getSubEntityByRel(this._rel);
-		if (!subEntity) return;
+		const parsedSirenEntity = sirenEntity && sirenEntity.hasSubEntityByRel(this._rel) && sirenEntity.getSubEntityByRel(this._rel);
+		if (!parsedSirenEntity) return;
 
 		if (SubEntityCollectionMap && SubEntityCollectionMap instanceof Map) {
-			subEntity.rel.forEach(rel => {
+			parsedSirenEntity.rel.forEach(rel => {
 				if (SubEntityCollectionMap.has(rel)) {
 					this._merge(SubEntityCollectionMap.get(rel));
 				}
@@ -48,16 +51,20 @@ export class SirenSubEntity extends Routable(Observable) {
 			});
 		}
 
-		this._setSubEntity(subEntity);
+		this._setSubEntity(parsedSirenEntity);
 	}
 
-	_merge(entity) {
-		if (!entity || !(entity instanceof SirenSubEntity)) {
+	/**
+	 *
+	 * @param {SirenSubEntity} sirenSubEntity - the observable object to merge
+	 */
+	_merge(sirenSubEntity) {
+		if (!sirenSubEntity || !(sirenSubEntity instanceof SirenSubEntity)) {
 			return;
 		}
 
-		this._observers.merge(entity._observers);
-		this._token = this._token || entity._token;
+		this._observers.merge(sirenSubEntity._observers);
+		this._token = this._token || sirenSubEntity._token;
 	}
 
 	async _setSubEntity(subEntity) {

--- a/state/observable/SirenSummonAction.js
+++ b/state/observable/SirenSummonAction.js
@@ -11,6 +11,14 @@ const defaultSummon = { has: false, summon: () => undefined };
  * Observable that uses an action to summon another entity
  */
 export class SirenSummonAction extends Routable(SirenAction) {
+
+	/**
+	 * The name is the identifier of the summon action
+	 */
+	static definedProperty({ name: id, token, verbose }) {
+		return { id, token, verbose };
+	}
+
 	/**
 	 * @param {Object} obj
 	 * @param {String} obj.id - The name of the action

--- a/state/observable/sirenObservableFactory.js
+++ b/state/observable/sirenObservableFactory.js
@@ -33,14 +33,13 @@ const observableClasses = Object.freeze({
  *
  * @param {*} param0
  */
-function definedProperty({ observable: type, prime, rel: id, route, token, state, verbose }) {
+function definedProperty({ observable: type, prime, rel: id, route, token, state }) {
 	return {
 		id,
 		route,
 		token: (prime || route) ? token : undefined,
 		type,
-		state,
-		verbose
+		state
 	};
 }
 

--- a/state/observable/sirenObservableFactory.js
+++ b/state/observable/sirenObservableFactory.js
@@ -29,13 +29,18 @@ const observableClasses = Object.freeze({
 	[observableTypes.summonAction]: SirenSummonAction
 });
 
-function definedProperty({ observable: type, prime, rel: id, route, token, state }) {
+/**
+ *
+ * @param {*} param0
+ */
+function definedProperty({ observable: type, prime, rel: id, route, token, state, verbose }) {
 	return {
 		id,
 		route,
 		token: (prime || route) ? token : undefined,
 		type,
-		state
+		state,
+		verbose
 	};
 }
 

--- a/test/observable/sirenSubEntities.test.js
+++ b/test/observable/sirenSubEntities.test.js
@@ -1,5 +1,6 @@
 import { assert }  from '@open-wc/testing';
-import SirenParse from 'siren-parser';
+import { SirenFacade } from '../../state/observable/SirenFacade.js';
+import { default as SirenParse } from 'siren-parser';
 import { SirenSubEntities } from '../../state/observable/SirenSubEntities.js';
 import { SirenSubEntity } from '../../state/observable/SirenSubEntity.js';
 import { subEntitiesTests } from '../data/observable/entities.js';
@@ -50,7 +51,7 @@ describe('sirenSubEntities set sirenEntity', () =>  {
 		assert.isTrue(subentites.entityMap.has('www.abc.com'), 'SirenSubEntities should have child stored');
 		const addedSubentity = subentites.entityMap.get('www.abc.com');
 		assert.instanceOf(addedSubentity, SirenSubEntity, 'SirenSubEntities child should be a SirenSubEntity');
-		assert.deepEqual(subentites.entities, entity.entities, 'SirenSubEntities entities should store one entity');
+		assert.deepEqual(subentites.entities, entity.entities.map(x => new SirenFacade(x)), 'SirenSubEntities entities should store one entity');
 	});
 
 	it('entity with two matching ids has been added as subentity', () => {
@@ -62,7 +63,7 @@ describe('sirenSubEntities set sirenEntity', () =>  {
 		assert.equal(subentites.entityMap.size, 2, 'SirenSubEntities should have 2 children');
 		assert.isTrue(subentites.entityMap.has('www.def.com'), 'SirenSubEntities should store first child');
 		assert.isTrue(subentites.entityMap.has('www.xyz.com'), 'SirenSubEntities should store second child');
-		assert.deepEqual(subentites.entities, entity.entities, 'SirenSubEntities entities should store two entities');
+		assert.deepEqual(subentites.entities, entity.entities.map(x => new SirenFacade(x)), 'SirenSubEntities entities should store two entities');
 	});
 
 	it('entity with two matching ids overwritten with one id', () => {
@@ -75,6 +76,6 @@ describe('sirenSubEntities set sirenEntity', () =>  {
 
 		assert.equal(subentites.entityMap.size, 1, 'SirenSubEntities should have 1 child');
 		assert.isTrue(subentites.entityMap.has('www.abc.com'), 'SirenSubEntities should have child stored');
-		assert.deepEqual(subentites.entities, entity2.entities, 'SirenSubEntities entities should store one entity');
+		assert.deepEqual(subentites.entities, entity2.entities.map(x => new SirenFacade(x)), 'SirenSubEntities entities should store one entity');
 	});
 });

--- a/test/state/HypermediaState.test.js
+++ b/test/state/HypermediaState.test.js
@@ -6,6 +6,7 @@ import { FetchError } from '../../state/Fetchable.js';
 import fetchMock from 'fetch-mock/esm/client.js';
 import { observableTypes } from '../../state/observable/sirenObservableFactory.js';
 import sinon from 'sinon/pkg/sinon-esm.js';
+import { SirenFacade } from '../../state/observable/SirenFacade.js';
 import SirenParse from 'siren-parser';
 import { waitUntil } from '@open-wc/testing-helpers';
 
@@ -103,13 +104,13 @@ describe('HypermediaState class', () => {
 			assert.deepEqual(observer.class, entity.class);
 			assert.deepEqual(observer.name, entity.properties.name);
 			assert.deepEqual(observer.description, entity.properties.description);
-			assertAreSimilar(observer.subEntity1, entity.entities[0]);
-			assertAreSimilar(observer.subEntity2, entity.entities[1]);
+			assertAreSimilar(observer.subEntity1, new SirenFacade(entity.entities[0]));
+			assertAreSimilar(observer.subEntity2, new SirenFacade(entity.entities[1]));
 			assertAreSimilar(observer.actionGet, { has: true });
 			assertAreSimilar(observer.actionPut, { has: true });
 			assert.equal(observer.linkNext, entity.links[0].href);
 			assert.equal(observer.linkSelf, entity.links[1].href);
-			assertAreSimilar(observer.subEntities, entity.entities);
+			assertAreSimilar(observer.subEntities, entity.entities.map(x => new SirenFacade(x)));
 			assertAreSimilar(observer.entity, entity);
 		});
 


### PR DESCRIPTION
## Context
[US123074](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fuserstory%2F461413871352&fdp=true?fdp=true)

The second and final portion of the `SirenFacade` story connects the new `SirenFacade` class into the following `Observable`s:

- `SirenSubEntity`: now reflects the `SirenFacade` instead of the parsed entity
- `SirenSubEntities`: reflects an Array of `SirenFacade` objects
- `SirenSummonAction`: reflects the same action, but returns a `SirenFacade` on `summon()`
- Added the `rel` property to the `SirenFacade`

## Quality
- Existing unit tests