### PR TITLE
fix: Add updateProperty to the Observable class

### DIFF
--- a/state/HypermediaState.js
+++ b/state/HypermediaState.js
@@ -130,7 +130,7 @@ class HypermediaState extends Fetchable(Object) {
 			const definedProperty = sirenObserverDefinedProperty(propertyInfo);
 			if (!definedProperty) return;
 			const sirenObservable = this._getSirenObservable(definedProperty);
-			sirenObservable && (sirenObservable.value = propertyInfo.value);
+			sirenObservable && (sirenObservable.updateProperty(propertyInfo.value));
 		});
 	}
 

--- a/state/observable/Observable.js
+++ b/state/observable/Observable.js
@@ -15,4 +15,12 @@ export class Observable {
 	}
 
 	setSirenEntity() {}
+
+	/**
+	 * Updates the property on all observers
+	 * @param value - The value to set the reflected property to
+	 */
+	updateProperty(value) {
+		this._observers.setProperty(value);
+	}
 }

--- a/state/observable/README.md
+++ b/state/observable/README.md
@@ -24,6 +24,7 @@ Observables are special properties defined by `foundation-components` that are *
 |`id`|`String`|What the observable is called in the Siren entity object - if not passed, default is the name of the property with or without an underscore|
 |`route`|`Array`|Route to the observable through the given array of observables (see below)|
 |`prime`|`Boolean`|Pre-fetch and cache the observable (see below)|
+|`verbose`|`Boolean`|Give a verbose version of the siren entity when requesting SirenFacades|
 
 ## Routing and Priming
 


### PR DESCRIPTION
This was something that was half implemented. It is now fully implemented (by changing like three lines 🤔)

This enables components to update the state without sending an action, like so:

```js
this._state.updateProperties({
	items: {
		observable: observableTypes.subEntities,
		rel: rels.item,
		value: newListOfItems
	}
});
```