### PR TITLE
fix: Fixed routing for nested summon actions

### DIFF
--- a/state/observable/Routable.js
+++ b/state/observable/Routable.js
@@ -25,7 +25,7 @@ export const Routable = superclass => class extends superclass {
 	 * @param {function} obj.method - A function that will mutate the value before setting the property
 	 */
 	addObserver(observer, property, { route, method } = {}) {
-		if (route) {
+		if (route && route[property]?.length !== 0) {
 			this._addRoute(observer, route);
 		} else {
 			super.addObserver(observer, property, { method });

--- a/test/example-components/component-integration.test.js
+++ b/test/example-components/component-integration.test.js
@@ -58,15 +58,42 @@ describe('Component integration', () => {
 		await waitUntil(() => mock.called(selfHref));
 
 		expect(element._hasAction('exampleAction'), 'does not have the action yet').to.be.undefined;
-		// the first API call will attach the summon action to the component
-		// the system should see the route parameter and automatically call summon
-		// then we wait until that response is received
-		// expect that this will fail until routing is added
-		// todo: remove these comments and this try catch block when test passes
 
 		await waitUntil(() => mock.called(actionHref));
 
-		await aTimeout(400); //Maya can too, so can Ten
+		await aTimeout(400);
 		expect(element._hasAction('exampleAction'), 'has the action').to.be.true;
+	});
+
+	it('gets an summon action routed through a summon action', async() => {
+		const selfHref = 'https://summon-action/entity-3';
+		const actionHref = 'https://summon-action/do-3';
+		const entity = {
+			actions: [{ href: actionHref, method: 'POST', name: 'example-summon' }],
+			links: [{ rel: ['self'], href: selfHref }]
+		};
+		const summonedActionHref = 'https://summoned-action/nested-summon';
+		const summonedEntity = {
+			actions: [{ href: summonedActionHref, name: 'example-nested-summon', method: 'POST' }]
+		};
+		const mock = fetchMock
+			.mock(selfHref, JSON.stringify(entity), {
+				delay: 100, // fake a slow network
+			})
+			.mock(actionHref, JSON.stringify(summonedEntity), {
+				delay: 100, // fake a slow network
+			});
+		const element = await fixture(html`
+			<summon-action-routed-summon-action-component href="${selfHref}" token="foo"></summon-action-routed-summon-action-component>
+		`);
+
+		await waitUntil(() => mock.called(selfHref));
+
+		expect(element._hasAction('nestedSummon'), 'does not have the action yet').to.be.undefined;
+
+		await waitUntil(() => mock.called(actionHref));
+
+		await aTimeout(400);
+		expect(element._hasAction('nestedSummon'), 'has the action').to.be.true;
 	});
 });

--- a/test/example-components/summon-action-components.js
+++ b/test/example-components/summon-action-components.js
@@ -25,5 +25,14 @@ class SummonActionRoutedActionComponent extends HypermediaStateMixin(LitElement)
 		};
 	}
 }
-
 customElements.define('summon-action-routed-action-component', SummonActionRoutedActionComponent);
+
+class SummonActionRoutedSummonActionComponent extends HypermediaStateMixin(LitElement) {
+	static get properties() {
+		return {
+			nestedSummon: { observable: observableTypes.summonAction, name: 'example-nested-summon',
+				route: [{ observable: observableTypes.summonAction, name: 'example-summon' }] }
+		};
+	}
+}
+customElements.define('summon-action-routed-summon-action-component', SummonActionRoutedSummonActionComponent);


### PR DESCRIPTION
Nested summon actions were not working properly. Now they do! Added a test to prove it.