### PR TITLE
fix: Remove await from the fetch

### DIFF
--- a/framework/lit/HypermediaStateMixin.js
+++ b/framework/lit/HypermediaStateMixin.js
@@ -58,7 +58,7 @@ export const HypermediaStateMixin = superclass => class extends superclass {
 			this.__gettingState = true;
 			this._state = await stateFactory(this.href, this.token);
 			this._state.addObservables(this, this._observables);
-			await fetch(this._state);
+			fetch(this._state);
 		} catch (error) {
 			console.error(error);
 		} finally {


### PR DESCRIPTION
The `await` breaks the localizeMixin from core.