### PR TITLE
feat: Added support for array fields

### DIFF
--- a/state/observable/SirenAction.js
+++ b/state/observable/SirenAction.js
@@ -73,6 +73,12 @@ export class SirenAction extends Fetchable(Observable) {
 		this._readyToSend = false;
 	}
 
+	/**
+	 * Sets the body of the request from the given input along with the other fields
+	 * Supports array inputs - will unpack the array into separate field entries
+	 * @param {Object} input - The inputs to commit
+	 * @return {String} The prepared body
+	 */
 	setBodyFromInput(input) {
 		if (this._rawSirenAction.type.indexOf('json') !== -1) {
 			this._body = JSON.stringify({ ...this._fields, ...input });
@@ -80,7 +86,12 @@ export class SirenAction extends Fetchable(Observable) {
 			const formData = new FormData();
 			const fields = { ...this._fields, ...input };
 			Object.keys(fields).forEach((name) => {
-				formData.append(name, fields[name]);
+				if (Array.isArray(fields[name])) {
+					// unpack the array and append each entry
+					fields[name].forEach(input => formData.append(name, input));
+				} else {
+					formData.append(name, fields[name]);
+				}
 			});
 			this._body = formData;
 		}
@@ -108,9 +119,11 @@ export class SirenAction extends Fetchable(Observable) {
 		this._updateAction();
 	}
 
-	// Doesn't support field names with the same name.
-	// todo: add support for array fields
-	// todo: change to getQueryParams
+	/**
+	 * Decodes the query parameters and fields for the action
+	 * Doesn't support fields with the same name - use an array for input in these cases
+	 * @param {Object} action - The raw action parsed from siren-parser
+	 */
 	_decodeFields(action) {
 		const url = new URL(action.href, window.location.origin);
 		const fields = {};

--- a/state/observable/SirenAction.js
+++ b/state/observable/SirenAction.js
@@ -77,7 +77,7 @@ export class SirenAction extends Fetchable(Observable) {
 	 * Sets the body of the request from the given input along with the other fields
 	 * Supports array inputs - will unpack the array into separate field entries
 	 * @param {Object} input - The inputs to commit
-	 * @return {String} The prepared body
+	 * @return {FormData} The prepared body
 	 */
 	setBodyFromInput(input) {
 		if (this._rawSirenAction.type.indexOf('json') !== -1) {
@@ -123,6 +123,7 @@ export class SirenAction extends Fetchable(Observable) {
 	 * Decodes the query parameters and fields for the action
 	 * Doesn't support fields with the same name - use an array for input in these cases
 	 * @param {Object} action - The raw action parsed from siren-parser
+	 * @returns {Object} Fields object
 	 */
 	_decodeFields(action) {
 		const url = new URL(action.href, window.location.origin);

--- a/test/example-components/action-components.js
+++ b/test/example-components/action-components.js
@@ -1,0 +1,12 @@
+import { HypermediaStateMixin } from '../../framework/lit/HypermediaStateMixin.js';
+import { LitElement } from 'lit-element';
+import { observableTypes } from '../../state/HypermediaState.js';
+
+class ActionComponent extends HypermediaStateMixin(LitElement) {
+	static get properties() {
+		return {
+			exampleAction: { observable: observableTypes.action, name: 'example-action' }
+		};
+	}
+}
+customElements.define('action-component', ActionComponent);

--- a/test/example-components/component-integration.test.js
+++ b/test/example-components/component-integration.test.js
@@ -1,101 +1,107 @@
 import './summon-action-components.js';
 import './subentities-components.js';
-import { aTimeout, expect, fixture, waitUntil } from '@open-wc/testing';
+import './action-components.js';
+import { expect, fixture, waitUntil } from '@open-wc/testing';
 import { default as fetchMock } from 'fetch-mock/esm/client.js';
 import { html } from 'lit-html';
 
 describe('Component integration', () => {
-	it('receives an entity when we summon one', async() => {
-		const selfHref = 'https://summon-action/entity';
-		const actionHref = 'https://summon-action/do';
-		const entity = {
-			actions: [{ href: actionHref, method: 'POST', name: 'example-summon' }],
-			links: [{ rel: ['self'], href: selfHref }]
-		};
-		const summonedEntity = {
-			properties: [{ someProperty: 'foobar' }]
-		};
-		const mock = fetchMock
-			.mock(selfHref, JSON.stringify(entity), {
-				delay: 50, // fake a slow network
-			})
-			.post(actionHref, JSON.stringify(summonedEntity), {
-				delay: 100, // fake a slow network
-			});
-		const element = await fixture(html`<summon-action-component href="${selfHref}" token="foo"></summon-action-component>`);
+	describe('Actions', () => {
+		afterEach(() => fetchMock.reset());
 
-		await waitUntil(() => mock.called(selfHref));
+		it('creates an action from the entity', async() => {
+			const selfHref = 'https://entity';
+			const actionHref = 'https://action/do';
+			const entity = {
+				actions: [{ href: actionHref, method: 'POST', name: 'example-action' }],
+				links: [{ rel: ['self'], href: selfHref }]
+			};
+			const mock = fetchMock.mock(selfHref, JSON.stringify(entity));
 
-		await aTimeout(300);
-		expect(element.summonedEntity).to.be.undefined;
-		expect(element._hasAction('exampleSummon')).to.be.true;
-		await element.getSummonedThing();
-		expect(element.summonedEntity).to.exist;
-		expect(element.summonedEntity.properties).to.deep.equal(summonedEntity.properties);
+			const element = await fixture(html`<action-component href="${selfHref}" token="foo"></action-component>`);
+			await waitUntil(() => element._state.fetchStatus.pending);
+			expect(element._hasAction('exampleAction')).to.be.false;
+			expect(mock.called(selfHref)).to.be.true;
+			await waitUntil(() => element._loaded === true);
+			expect(element._hasAction('exampleAction')).to.be.true;
+		});
 	});
+	describe('Summon Actions', () => {
+		it('receives an entity when we summon one', async() => {
+			const selfHref = 'https://summon-action/entity';
+			const actionHref = 'https://summon-action/do';
+			const entity = {
+				actions: [{ href: actionHref, method: 'POST', name: 'example-summon' }],
+				links: [{ rel: ['self'], href: selfHref }]
+			};
+			const summonedEntity = {
+				properties: [{ someProperty: 'foobar' }]
+			};
+			const mock = fetchMock
+				.mock(selfHref, JSON.stringify(entity), {
+					delay: 50, // fake a slow network
+				})
+				.post(actionHref, JSON.stringify(summonedEntity), {
+					delay: 100, // fake a slow network
+				});
+			const element = await fixture(html`<summon-action-component href="${selfHref}" token="foo"></summon-action-component>`);
 
-	it('gets an action routed through a summon action', async() => {
-		const selfHref = 'https://summon-action/entity-2';
-		const actionHref = 'https://summon-action/do-2';
-		const entity = {
-			actions: [{ href: actionHref, method: 'POST', name: 'example-summon' }],
-			links: [{ rel: ['self'], href: selfHref }]
-		};
-		const summonedActionHref = 'https://summoned-action/';
-		const summonedEntity = {
-			actions: [{ href: summonedActionHref, name: 'example-action', method: 'PUT' }]
-		};
-		const mock = fetchMock
-			.mock(selfHref, JSON.stringify(entity), {
-				delay: 100, // fake a slow network
-			})
-			.mock(actionHref, JSON.stringify(summonedEntity), {
-				delay: 100, // fake a slow network
-			});
-		const element = await fixture(html`
-			<summon-action-routed-action-component href="${selfHref}" token="foo"></summon-action-routed-action-component>
-		`);
+			await waitUntil(() => element._loaded === true);
+			expect(mock.called(selfHref)).to.be.true;
+			expect(element.summonedEntity).to.be.undefined;
+			expect(element._hasAction('exampleSummon')).to.be.true;
+			await element.getSummonedThing();
+			expect(element.summonedEntity).to.exist;
+			expect(element.summonedEntity.properties).to.deep.equal(summonedEntity.properties);
+		});
 
-		await waitUntil(() => mock.called(selfHref));
+		it('gets an action routed through a summon action', async() => {
+			const selfHref = 'https://summon-action/entity-2';
+			const actionHref = 'https://summon-action/do-2';
+			const entity = {
+				actions: [{ href: actionHref, method: 'POST', name: 'example-summon' }],
+				links: [{ rel: ['self'], href: selfHref }]
+			};
+			const summonedActionHref = 'https://summoned-action/';
+			const summonedEntity = {
+				actions: [{ href: summonedActionHref, name: 'example-action', method: 'PUT' }]
+			};
+			const mock = fetchMock
+				.mock(selfHref, JSON.stringify(entity))
+				.mock(actionHref, JSON.stringify(summonedEntity));
+			const element = await fixture(html`
+				<summon-action-routed-action-component href="${selfHref}" token="foo"></summon-action-routed-action-component>
+			`);
 
-		expect(element._hasAction('exampleAction'), 'does not have the action yet').to.be.undefined;
+			expect(element._hasAction('exampleAction'), 'does not have the action yet').to.be.undefined;
+			await waitUntil(() => element._loaded === true);
+			expect(mock.called(actionHref)).to.be.true;
+			expect(element._hasAction('exampleAction'), 'has the action').to.be.true;
+		});
 
-		await waitUntil(() => mock.called(actionHref));
-
-		await aTimeout(400);
-		expect(element._hasAction('exampleAction'), 'has the action').to.be.true;
-	});
-
-	it('gets an summon action routed through a summon action', async() => {
-		const selfHref = 'https://summon-action/entity-3';
-		const actionHref = 'https://summon-action/do-3';
-		const entity = {
-			actions: [{ href: actionHref, method: 'POST', name: 'example-summon' }],
-			links: [{ rel: ['self'], href: selfHref }]
-		};
-		const summonedActionHref = 'https://summoned-action/nested-summon';
-		const summonedEntity = {
-			actions: [{ href: summonedActionHref, name: 'example-nested-summon', method: 'POST' }]
-		};
-		const mock = fetchMock
-			.mock(selfHref, JSON.stringify(entity), {
-				delay: 100, // fake a slow network
-			})
-			.mock(actionHref, JSON.stringify(summonedEntity), {
-				delay: 100, // fake a slow network
-			});
-		const element = await fixture(html`
-			<summon-action-routed-summon-action-component href="${selfHref}" token="foo"></summon-action-routed-summon-action-component>
-		`);
-
-		await waitUntil(() => mock.called(selfHref));
-
-		expect(element._hasAction('nestedSummon'), 'does not have the action yet').to.be.undefined;
-
-		await waitUntil(() => mock.called(actionHref));
-
-		await aTimeout(400);
-		expect(element._hasAction('nestedSummon'), 'has the action').to.be.true;
+		it('gets an summon action routed through a summon action', async() => {
+			const selfHref = 'https://summon-action/entity-3';
+			const actionHref = 'https://summon-action/do-3';
+			const entity = {
+				actions: [{ href: actionHref, method: 'POST', name: 'example-summon' }],
+				links: [{ rel: ['self'], href: selfHref }]
+			};
+			const summonedActionHref = 'https://summoned-action/nested-summon';
+			const summonedEntity = {
+				actions: [{ href: summonedActionHref, name: 'example-nested-summon', method: 'POST' }]
+			};
+			const mock = fetchMock
+				.mock(selfHref, JSON.stringify(entity))
+				.mock(actionHref, JSON.stringify(summonedEntity));
+			const element = await fixture(html`
+				<summon-action-routed-summon-action-component href="${selfHref}" token="foo"></summon-action-routed-summon-action-component>
+			`);
+			expect(element._hasAction('nestedSummon'), 'does not have the action yet').to.be.undefined;
+			await waitUntil(() => element._loaded === true);
+			expect(mock.called(selfHref)).to.be.true;
+			expect(mock.called(actionHref)).to.be.true;
+			expect(element._hasAction('nestedSummon'), 'has the action').to.be.true;
+		});
 	});
 
 	describe('SubEntities', () => {

--- a/test/observable/sirenAction.test.js
+++ b/test/observable/sirenAction.test.js
@@ -1,2 +1,49 @@
-// import { assert }  from '@open-wc/testing';
-// import { SirenAction } from '../../state/observable/SirenAction.js';
+import { expect } from '@open-wc/testing';
+import { SirenAction } from '../../state/observable/SirenAction.js';
+
+describe('SirenAction', () => {
+	describe('setBodyFromInput', () => {
+		let action;
+		beforeEach(() => action = new SirenAction({ id: 'example-action', token: 'foo' }));
+
+		it('sets the body for json requests', () => {
+			action._fields = { 'someField': 'someValue' };
+			action._rawSirenAction = { type: ['json'], method: 'POST' };
+			action.setBodyFromInput({ 'anotherField': 'anotherValue' });
+			expect(action._body, 'body is a string').to.be.a('string');
+			expect(JSON.parse(action._body), 'body equals the json').to.deep.equal({
+				'anotherField': 'anotherValue', 'someField': 'someValue'
+			});
+		});
+
+		it('does not set the body for GET and HEAD requests', () => {
+			action._fields = { 'someField': 'someValue' };
+			action._rawSirenAction = { type: [], method: 'GET' };
+			action.setBodyFromInput({ 'anotherField': 'anotherValue' });
+			expect(action._body).to.be.null;
+
+			action._rawSirenAction = { type: [], method: 'HEAD' };
+			action.setBodyFromInput({ 'anotherField': 'anotherValue' });
+			expect(action._body).to.be.null;
+		});
+
+		it('sets the body from a given input', () => {
+			action._fields = { 'someField': 'someValue' };
+			action._rawSirenAction = { type: [], method: 'POST' };
+			action.setBodyFromInput({ 'anotherField': 'anotherValue' });
+			expect(action._body, 'body is a FormData object').to.be.a('formdata');
+			expect(action._body.has('someField'), 'body has the old field').to.be.true;
+			expect(action._body.has('anotherField'), 'body has the new field').to.be.true;
+		});
+
+		it('sets the body from an input with an array value', () => {
+			action._rawSirenAction = { type: [], method: 'POST' };
+			action.setBodyFromInput({ 'arrayField': [1, 2, 3] });
+			expect(action._body, 'body is a FormData object').to.be.a('formdata');
+			expect(action._body.has('arrayField'), 'body has the new field').to.be.true;
+			expect(action._body.getAll('arrayField'), 'field has all of the values').to.deep.equal([
+				'1', '2', '3'
+			]);
+		});
+	});
+});


### PR DESCRIPTION
## Context
[US122856](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fuserstory%2F459739288064&fdp=true?fdp=true)

Engine portion of the story. The new `bulk-update-collection` action takes fields in the form of:
```
inputIds: 1
inputIds: 2
```
Previously, the engine did not support fields with the same name. I've remedied this in this PR. Now, in the component, we do this with an action like so:
```js
this.someAction.commit({
    inputIds: [1, 2]
});
```
The engine will automagically unpack it into multiple formData entries.

## Quality
- New very basic unit tests added for `SirenAction`. None existed before. We should add more.
- Basic integration test for `actions` added
- Cleaned up existing integration tests so they no longer use `aTimeout`