### PR TITLE
fix: Check for undefined instead of committing an object

### DIFF
--- a/state/observable/SirenAction.js
+++ b/state/observable/SirenAction.js
@@ -1,7 +1,6 @@
 import { Fetchable, FetchError } from '../Fetchable.js';
 import { fetch } from '../fetch.js';
 import { Observable } from './Observable.js';
-import { observableTypes } from './sirenObservableFactory.js';
 
 const defaultAction = { has: false, commit: () => undefined };
 

--- a/state/observable/SirenAction.js
+++ b/state/observable/SirenAction.js
@@ -1,6 +1,7 @@
 import { Fetchable, FetchError } from '../Fetchable.js';
 import { fetch } from '../fetch.js';
 import { Observable } from './Observable.js';
+import { observableTypes } from './sirenObservableFactory.js';
 
 const defaultAction = { has: false, commit: () => undefined };
 
@@ -149,7 +150,9 @@ export class SirenAction extends Fetchable(Observable) {
 	_prepareAction(observables) {
 		const input = {};
 		if (observables) {
-			Object.keys(observables).forEach(field => input[field] = observables[field]?.value ? observables[field].value : observables[field]);
+			Object.keys(observables).forEach((field) => {
+				input[field] = observables[field]?.value !== undefined ? observables[field].value : observables[field];
+			});
 		}
 		this.setQueryParams(input);
 		this.setBodyFromInput(input);


### PR DESCRIPTION
## Context
Users can create learning paths with empty names and descriptions which are converted to "[Object object]"

This PR commits an empty string instead - it is the component's job to validate.

## Quality
Tested on `polarisdev2` with local BSI