### PR TITLE
fix: Use while exec instead of matchAll

### DIFF
--- a/framework/lit/HypermediaResult.js
+++ b/framework/lit/HypermediaResult.js
@@ -75,8 +75,7 @@ export class HypermediaResult extends TemplateResult {
 		}
 
 		// return all of this information as a TemplateResult to be stored as a value for a different Result
-		const result = new TemplateResult(mainStrings, mainValues, 'html', defaultTemplateProcessor);
-		return result;
+		return new TemplateResult(mainStrings, mainValues, 'html', defaultTemplateProcessor);
 	}
 
 	/*

--- a/framework/lit/HypermediaResult.js
+++ b/framework/lit/HypermediaResult.js
@@ -75,8 +75,8 @@ export class HypermediaResult extends TemplateResult {
 		}
 
 		// return all of this information as a TemplateResult to be stored as a value for a different Result
-
-		return new TemplateResult(mainStrings, mainValues, 'html', defaultTemplateProcessor);
+		const result = new TemplateResult(mainStrings, mainValues, 'html', defaultTemplateProcessor);
+		return result;
 	}
 
 	/*
@@ -210,15 +210,14 @@ export class HypermediaResult extends TemplateResult {
 		};
 		const resources = { classes: [] };
 		const components = componentStoreFactory(pseudoTag);
-		console.log('renderhmcomponent');
 		if (!href || !token) return this._skeletonRender(components);
-		console.log('boop');
 		const statePromise = stateFactory(href, token);
 		const fetchedResults  = statePromise.then(async state => {
 			state.addObservables(resources, observable);
 			await fetch(state);
 			return state;
 		}).then(state => this.render(state, components, resources, pseudoTag, strings, values));
+		this._fetchedResults = fetchedResults; // exposing for easier testing
 		return html`${until(fetchedResults, this._skeletonRender(components))}`;
 	}
 

--- a/framework/lit/HypermediaResult.js
+++ b/framework/lit/HypermediaResult.js
@@ -82,12 +82,17 @@ export class HypermediaResult extends TemplateResult {
 	/*
 	*  Determines the href and token associated with the current element
 	*/
-
 	getHrefToken(strings, values) {
 		let href, token;
 		strings = [...strings];
 		strings.forEach((string, index) => {
-			const output = [...string.matchAll(/(token=)|(href=)/g)].pop();
+			const matches = [];
+			let match;
+			const regex = /(token=)|(href=)/g;
+			while ((match = regex.exec(string)) !== null) {
+				matches.push(match);
+			}
+			const output = [...matches].pop();
 			if (output && output[1]) {
 				token = values[index];
 			} else if (output && output[2]) {
@@ -106,15 +111,16 @@ export class HypermediaResult extends TemplateResult {
 		return super.getHTML();
 	}
 
-	/*
+	/**
 	* Function called on a HypermediaResult to process the strings
 	* most importantly, this finds any base tags that exist and starts
 	* the process to recursively resolve them
-	* - strings is an array of strings of length n
-	* - values is an array of length n-1 html values
+	* @param { Object } obj
+	* @param { Array } obj.strings The array of strings to process of length n
+	* @param { Array } obj.values The values of length n-1 html values
 	* strings[0] + values[0] + strings[1] + values[1] + ... + strings[n-1] + values[n-1] + strings[n]
-	*   forms an html string
-	*/
+	* forms an html string
+	**/
 
 	processing() {
 		const stringCollections = [{ strings: [], values: [] }];
@@ -135,8 +141,14 @@ export class HypermediaResult extends TemplateResult {
 			*  output[2] - tagname if it matched <\tagname
 			*  output.index: the first index of tagname including prefix in strings[i]
 			*/
+			const matches = [];
+			let match;
 			// eslint-disable-next-line no-useless-escape
-			const outputs = [...strings[i].matchAll(/\<([A-Za-z][A-Za-z0-9\-]*)|\<\/([A-Za-z][A-Za-z0-9\-]*)\>/g)];
+			const regex = /\<([A-Za-z][A-Za-z0-9\-]*)|\<\/([A-Za-z][A-Za-z0-9\-]*)\>/g;
+			while ((match = regex.exec(currentString)) !== null) {
+				matches.push(match);
+			}
+			const outputs = [...matches];
 			outputs.forEach(output => {
 				// the tag is an opening tag and a pseudotag
 				if (output[1] && isPseudoTag(output[1])) {
@@ -198,7 +210,9 @@ export class HypermediaResult extends TemplateResult {
 		};
 		const resources = { classes: [] };
 		const components = componentStoreFactory(pseudoTag);
+		console.log('renderhmcomponent');
 		if (!href || !token) return this._skeletonRender(components);
+		console.log('boop');
 		const statePromise = stateFactory(href, token);
 		const fetchedResults  = statePromise.then(async state => {
 			state.addObservables(resources, observable);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@open-wc/testing": "^2.5.29",
     "@open-wc/testing-karma": "^4.0.8",
     "babel-eslint": "^10.1.0",
+    "babel-plugin-rewire-exports": "^2.3.0",
     "eslint": "^7.10.0",
     "eslint-config-brightspace": "^0.11.0",
     "eslint-plugin-html": "^6.1.0",
@@ -28,6 +29,7 @@
     "eslint-plugin-sort-class-members": "^1.8.0",
     "fetch-mock": "^9.11.0",
     "karma-sauce-launcher": "^4.1.5",
+    "rewire": "^5.0.0",
     "sinon": "^9.2.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@open-wc/testing": "^2.5.29",
     "@open-wc/testing-karma": "^4.0.8",
     "babel-eslint": "^10.1.0",
-    "babel-plugin-rewire-exports": "^2.3.0",
     "eslint": "^7.10.0",
     "eslint-config-brightspace": "^0.11.0",
     "eslint-plugin-html": "^6.1.0",
@@ -29,7 +28,6 @@
     "eslint-plugin-sort-class-members": "^1.8.0",
     "fetch-mock": "^9.11.0",
     "karma-sauce-launcher": "^4.1.5",
-    "rewire": "^5.0.0",
     "sinon": "^9.2.1"
   },
   "dependencies": {

--- a/test/example-components/component-integration.test.js
+++ b/test/example-components/component-integration.test.js
@@ -105,7 +105,7 @@ describe('Component integration', () => {
 	});
 
 	describe('SubEntities', () => {
-		beforeEach(() => {
+		afterEach(() => {
 			fetchMock.reset();
 		});
 

--- a/test/framework/lit/hypermedia-result.test.js
+++ b/test/framework/lit/hypermedia-result.test.js
@@ -1,6 +1,5 @@
 import { customHypermediaElement, html } from '../../../framework/lit/hypermedia-components.js';
-import { expect, aTimeout }  from '@open-wc/testing';
-import { stateFactory } from '../../../state/HypermediaState.js';
+import { expect }  from '@open-wc/testing';
 import { default as fetchMock } from 'fetch-mock/esm/client.js';
 import { html as lithtml } from 'lit-element';
 
@@ -11,7 +10,7 @@ customElements.define('test-component', TestComponent);
 customHypermediaElement('test-hm-component', TestHMComponent);
 customHypermediaElement('test-hm-component-extend', TestHMComponentExtend, 'test-hm-component', [['class1']]);
 
-describe.only('Lit-element Framework Integration', () => {
+describe('Lit-element Framework Integration', () => {
 
 	it('outputs the same as lit html if element is not a Hypermedia element', () => {
 		expect(html``).to.deep.equal(lithtml``);
@@ -31,22 +30,6 @@ describe.only('Lit-element Framework Integration', () => {
 	});
 
 	describe('HypermediaResult', () => {
-		it('creates a HypermediaResult from an empty string', () => {
-			const result = html``;
-			const litResult = lithtml``;
-			expect(result).to.have.property('strings');
-			expect(result.strings).to.be.an('array');
-			expect(result).to.deep.equal(litResult);
-		});
-
-		it('creates a HypermediaResult from a regular element', () => {
-			const result = html`<div></div>`;
-			const litResult = lithtml`<div></div>`;
-			expect(result).to.have.property('strings');
-			expect(result.strings).to.be.an('array');
-			expect(result).to.deep.equal(litResult);
-		});
-
 		it('creates a HypermediaResult from a component with an href and token', () => {
 			const href = 'http://cupcake.ca';
 			const token = 'cookie';
@@ -66,19 +49,22 @@ describe.only('Lit-element Framework Integration', () => {
 				.to.deep.equal(litResult);
 		});
 
-		it('resolves a tag that extends the base tag from the hypermedia classes', async() => {
-			const href = 'https://entity';
+		it('resolves a tag that extends the base tag from the hypermedia classes', () => {
+			const href = 'https://entity/';
+			const token = 'foo';
 			const entity = {
 				class: ['class1']
 			};
 			const mock = fetchMock.mock(href, JSON.stringify(entity));
-			const hypermediaResult = html`<test-hm-component href="${href}" .token="foo"></test-hm-component>`;
-			console.log(hypermediaResult.strings, hypermediaResult.values[0]);
-			//console.log(hypermediaResult.getHrefToken(hypermediaResult.strings, hypermediaResult.values));
-			const state = await stateFactory(href, 'foo');
-			await state.allFetchesComplete(); // same promise as the one being awaited from the hypermedia render
-			//await aTimeout(300);
-			console.log(hypermediaResult.strings, hypermediaResult.values[0]);
+			const hypermediaResult = html`<test-hm-component href="${href}" .token="${token}"></test-hm-component>`;
+
+			hypermediaResult._fetchedResults.then(result => {
+				expect(mock.called(href)).to.be.true;
+				expect(result.strings).to.deep.equal(['<test-hm-component-extend href="', '" .token="', '"></test-hm-component-extend>']);
+				expect(result.values).to.deep.equal([href, token]);
+				fetchMock.reset();
+			});
+
 		});
 	});
 });

--- a/test/framework/lit/hypermedia-result.test.js
+++ b/test/framework/lit/hypermedia-result.test.js
@@ -1,0 +1,84 @@
+import { customHypermediaElement, html } from '../../../framework/lit/hypermedia-components.js';
+import { expect, aTimeout }  from '@open-wc/testing';
+import { stateFactory } from '../../../state/HypermediaState.js';
+import { default as fetchMock } from 'fetch-mock/esm/client.js';
+import { html as lithtml } from 'lit-element';
+
+class TestComponent { }
+class TestHMComponent { }
+class TestHMComponentExtend { }
+customElements.define('test-component', TestComponent);
+customHypermediaElement('test-hm-component', TestHMComponent);
+customHypermediaElement('test-hm-component-extend', TestHMComponentExtend, 'test-hm-component', [['class1']]);
+
+describe.only('Lit-element Framework Integration', () => {
+
+	it('outputs the same as lit html if element is not a Hypermedia element', () => {
+		expect(html``).to.deep.equal(lithtml``);
+		expect(html`<div></div>`).to.deep.equal(lithtml`<div></div>`);
+		const value = 'foo';
+		expect(html`<div thing="${value}"></div>`).to.deep.equal(lithtml`<div thing="${value}"></div>`);
+		expect(html`<test-component></test-component>`).to.deep.equal(lithtml`<test-component></test-component>`);
+		expect(html`<test-component value="${value}"></test-component>`).to.deep.equal(lithtml`<test-component value="${value}"></test-component>`);
+	});
+
+	describe('customHypermediaElement', () => {
+		it('correctly adds the hm component tags to the component store', () => {
+			const component = window.D2L.ComponentStore.get('test-hm-component');
+			expect(component._elementPseudoTag).equals('test-hm-component');
+			expect(component._componentStore.get('class1').get(null)).equals('test-hm-component-extend');
+		});
+	});
+
+	describe('HypermediaResult', () => {
+		it('creates a HypermediaResult from an empty string', () => {
+			const result = html``;
+			const litResult = lithtml``;
+			expect(result).to.have.property('strings');
+			expect(result.strings).to.be.an('array');
+			expect(result).to.deep.equal(litResult);
+		});
+
+		it('creates a HypermediaResult from a regular element', () => {
+			const result = html`<div></div>`;
+			const litResult = lithtml`<div></div>`;
+			expect(result).to.have.property('strings');
+			expect(result.strings).to.be.an('array');
+			expect(result).to.deep.equal(litResult);
+		});
+
+		it('creates a HypermediaResult from a component with an href and token', () => {
+			const href = 'http://cupcake.ca';
+			const token = 'cookie';
+			const third = 'cake';
+			const result = html`<test-component href="${href}" token="${token}" cup="${third}"></test-component>`;
+			const litResult = lithtml`<test-component href="${href}" token="${token}" cup="${third}"></test-component>`;
+			expect(result).to.deep.equal(litResult);
+			expect(result.strings).to.deep.equal(['<test-component href="', '" token="', '" cup="', '"></test-component>']);
+			expect(result.getHrefToken(result.strings, result.values)).to.deep.equal([href, token]);
+		});
+
+		it ('resolves to the skeleton with the regular TemplateResult attached as a value', () => {
+			const href = 'http://d2l.com';
+			const hypermediaResult = html`<test-hm-component href="${href}" token="foo"></test-hm-component>`;
+			const litResult = lithtml`<test-hm-component skeleton></test-hm-component>`;
+			expect(hypermediaResult.values[0], 'processed hm component resolves to the skeleton')
+				.to.deep.equal(litResult);
+		});
+
+		it('resolves a tag that extends the base tag from the hypermedia classes', async() => {
+			const href = 'https://entity';
+			const entity = {
+				class: ['class1']
+			};
+			const mock = fetchMock.mock(href, JSON.stringify(entity));
+			const hypermediaResult = html`<test-hm-component href="${href}" .token="foo"></test-hm-component>`;
+			console.log(hypermediaResult.strings, hypermediaResult.values[0]);
+			//console.log(hypermediaResult.getHrefToken(hypermediaResult.strings, hypermediaResult.values));
+			const state = await stateFactory(href, 'foo');
+			await state.allFetchesComplete(); // same promise as the one being awaited from the hypermedia render
+			//await aTimeout(300);
+			console.log(hypermediaResult.strings, hypermediaResult.values[0]);
+		});
+	});
+});

--- a/test/hypermedia-components.test.js
+++ b/test/hypermedia-components.test.js
@@ -3,7 +3,7 @@ import { assert }  from '@open-wc/testing';
 import { componentStoreFactory } from '../render/componentFactory.js';
 //import sinon from 'sinon/pkg/sinon-esm.js';
 
-describe('Tester', () => {
+describe('Component Store', () => {
 
 	it('should register d2l-activity-name for customHypermediaElement', async() => {
 		window.D2L = window.D2L || {};


### PR DESCRIPTION
## Context
[US124640](https://rally1.rallydev.com/#/357252966636d/dashboard?detail=%2Fuserstory%2F492652604048&fdp=true?fdp=true)
https://github.com/BrightspaceHypermediaComponents/foundation-engine/pull/80

Changes the `matchAll` function within the `HypermediaResults` class to use a `while` loop with the `exec` function to perform regex processing because `matchAll` is not supported in Legacy Edge. This solution was chosen over a polyfill.

**Note:** `exec` was chosen over the `match` function because the global flag is required. `match` will ignore capture groups whenever the global flag is set, where exec does not. See also: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#description

New integration tests added to test the functionality of the custom `html` function, the `customHypermediaElement` function, and the processing performed by `HypermediaResult`.

## Quality
- New integration tests added for previously uncovered code
- There is a new Promise object exposed in `HypermediaResult` which is strictly for testing. This was to avoid needing to mock out the functionality of the `until` directive. It can likely be removed once we have an alternative to `fixture` from `open-wc/testing` - currently our `HypermediaResult` does not work with `fixture`