### PR TITLE
fix: Update Deep copy to handle cycles and added tests.

### DIFF
--- a/helper/deepCopy.js
+++ b/helper/deepCopy.js
@@ -1,4 +1,4 @@
-export function deepCopy(inObject) {
+export function deepCopy(inObject, copiedObjects = null) {
 	if (typeof inObject !== 'object' || inObject === null) {
 		return inObject; // Return the value if inObject is not an object
 	}
@@ -6,12 +6,19 @@ export function deepCopy(inObject) {
 	// Create an array or object to hold the values
 	const outObject = Array.isArray(inObject) ? [] : {};
 
+	// What if there is a cycle?
+	copiedObjects = copiedObjects === null ? new WeakMap() : copiedObjects;
+	if (copiedObjects.has(inObject)) {
+		return copiedObjects.get(inObject);
+	}
+	copiedObjects.set(inObject, outObject);
+
 	let value;
 	for (const key in inObject) {
 		value = inObject[key];
 
 		// Recursively (deep) copy for nested objects, including arrays
-		outObject[key] = deepCopy(value);
+		outObject[key] = deepCopy(value, copiedObjects);
 	}
 
 	return outObject;

--- a/test/example-components/component-integration.test.js
+++ b/test/example-components/component-integration.test.js
@@ -248,7 +248,9 @@ describe('Component integration', () => {
 				await elements[0].updateItems(newItems);
 
 				elements.forEach(element => {
+					// copy not a ref
 					expect(element.items).to.deep.equal(newItems);
+					expect(element.items).to.not.equal(newItems);
 				});
 			});
 		});

--- a/test/example-components/component-integration.test.js
+++ b/test/example-components/component-integration.test.js
@@ -130,38 +130,6 @@ describe('Component integration', () => {
 			expect(element.items[0].properties.prop1).to.be.equal('foo');
 		});
 
-		it('will load multiple components listening to the same subEntities ', async() => {
-			const selfHref = 'https://entity';
-			const subEntities = [];
-			for (let i = 0; i < 5; i++) {
-				subEntities.push({
-					properties: { itemNumber: i },
-					rel: ['item']
-				});
-			}
-			const entity = {
-				entities: subEntities,
-				links: [{ rel: ['self'], href: selfHref }]
-			};
-			const mock = fetchMock.mock(selfHref, JSON.stringify(entity));
-			const elements = [];
-			for (let i = 0; i < 5; i++) {
-				elements.push(await fixture(html`<subentities-component-modified-list href="${selfHref}" token="someToken"></subentities-component-modified-list>`));
-			}
-			await waitUntil(() => elements[0]._loaded === true);
-			elements.forEach(element => {
-				expect(mock.called(selfHref)).to.be.true;
-				expect(element.items).to.exist;
-				expect(element.items).to.be.an('array');
-				expect(element.items).to.have.lengthOf(5);
-				let uniqueId = null;
-				element.items.forEach((item, key) => {
-					uniqueId = uniqueId === null ? item.properties.itemNumber : uniqueId;
-					expect(item.properties.itemNumber).to.be.equal(key + uniqueId);
-				});
-			});
-		});
-
 		it('gets the routed subEntities', async() => {
 			const selfHref = 'https://entity';
 			const linkedHref = 'https://entity/linked';
@@ -229,6 +197,60 @@ describe('Component integration', () => {
 			expect(elementWithRouting.items[0].properties.newProp, 'routed component sees change').to.be.equal('cupcake');
 			expect(element.items[0].properties.newProp, 'component directly observing sees change').to.be.equal('cupcake');
 
+		});
+		describe('loading multiple subentities listening to the same state', () => {
+			const numberOfComponents = 5;
+			const numberOfItems = 5;
+			let elements, mock;
+			const selfHref = 'https://entity';
+
+			beforeEach(async() => {
+				const subEntities = [];
+				for (let i = 0; i < numberOfItems; i++) {
+					subEntities.push({
+						properties: { itemNumber: i },
+						rel: ['item']
+					});
+				}
+				const entity = {
+					entities: subEntities,
+					links: [{ rel: ['self'], href: selfHref }]
+				};
+				mock = fetchMock.mock(selfHref, JSON.stringify(entity));
+				elements = [];
+				for (let i = 0; i < numberOfComponents; i++) {
+					elements.push(await fixture(html`<subentities-component-modified-list href="${selfHref}" token="someToken"></subentities-component-modified-list>`));
+				}
+				await waitUntil(() => elements[0]._loaded === true);
+			});
+
+			afterEach(() => {
+				mock.resetHistory();
+				clearStore();
+			});
+
+			it('will load multiple components listening to the same subEntities', async() => {
+				elements.forEach(element => {
+					expect(mock.called(selfHref)).to.be.true;
+					expect(element.items).to.exist;
+					expect(element.items).to.be.an('array');
+					expect(element.items).to.have.lengthOf(numberOfItems);
+					let uniqueId = null;
+					element.items.forEach((item, key) => {
+						uniqueId = uniqueId === null ? item.properties.itemNumber : uniqueId;
+						expect(item.properties.itemNumber).to.be.equal(key + uniqueId);
+					});
+				});
+			});
+
+			it('will change all instances when one updates the state', async() => {
+				const newItems = ['one', 'two', 'three'];
+				await elements[0].updateItems(newItems);
+
+				elements.forEach(element => {
+					expect(element.items).to.deep.equal(newItems);
+				});
+			});
 		});
 	});
 });

--- a/test/example-components/component-integration.test.js
+++ b/test/example-components/component-integration.test.js
@@ -222,6 +222,7 @@ describe('Component integration', () => {
 					elements.push(await fixture(html`<subentities-component-modified-list href="${selfHref}" token="someToken"></subentities-component-modified-list>`));
 				}
 				await waitUntil(() => elements[0]._loaded === true);
+				expect(mock.called(selfHref)).to.be.true;
 			});
 
 			afterEach(() => {
@@ -231,7 +232,6 @@ describe('Component integration', () => {
 
 			it('will load multiple components listening to the same subEntities', async() => {
 				elements.forEach(element => {
-					expect(mock.called(selfHref)).to.be.true;
 					expect(element.items).to.exist;
 					expect(element.items).to.be.an('array');
 					expect(element.items).to.have.lengthOf(numberOfItems);

--- a/test/example-components/subentities-components.js
+++ b/test/example-components/subentities-components.js
@@ -2,6 +2,10 @@ import { HypermediaStateMixin } from '../../framework/lit/HypermediaStateMixin.j
 import { LitElement } from 'lit-element';
 import { observableTypes } from '../../state/HypermediaState.js';
 
+function uniqueId() {
+	return Math.floor(Math.random() * 10000);
+}
+
 class SubEntitiesComponent extends HypermediaStateMixin(LitElement) {
 	static get properties() {
 		return {
@@ -44,3 +48,30 @@ class RoutedSubEntitiesComponent extends HypermediaStateMixin(LitElement) {
 	}
 }
 customElements.define('routed-subentities-component', RoutedSubEntitiesComponent);
+
+class SubEntitiesComponentModifiedList extends HypermediaStateMixin(LitElement) {
+	static get properties() {
+		return {
+			items: {
+				observable: observableTypes.subEntities,
+				rel: 'item',
+				method: (items) => {
+					const unqiueId = uniqueId();
+					items.forEach(item => item.properties.itemNumber = unqiueId + item.properties.itemNumber);
+					return items;
+				}
+			}
+		};
+	}
+
+	async updateItems(items) {
+		this._state.updateProperties({
+			items: {
+				observable: observableTypes.subEntities,
+				rel: 'item',
+				value: items
+			}
+		});
+	}
+}
+customElements.define('subentities-component-modified-list', SubEntitiesComponentModifiedList);

--- a/test/example-components/subentities-components.js
+++ b/test/example-components/subentities-components.js
@@ -57,7 +57,11 @@ class SubEntitiesComponentModifiedList extends HypermediaStateMixin(LitElement) 
 				rel: 'item',
 				method: (items) => {
 					const unqiueId = uniqueId();
-					items.forEach(item => item.properties.itemNumber = unqiueId + item.properties.itemNumber);
+					items.forEach(item => {
+						if (item.properties) {
+							item.properties.itemNumber = unqiueId + item.properties.itemNumber;
+						}
+					});
 					return items;
 				}
 			}

--- a/test/helper/deepCopy.test.js
+++ b/test/helper/deepCopy.test.js
@@ -1,0 +1,130 @@
+
+import { deepCopy } from '../../helper/deepCopy.js';
+import { expect } from '@open-wc/testing';
+
+describe('deepCopy', () => {
+	const changedObject = {
+		number: 42,
+		string: 'Fluffy',
+		undefined: 'not undefined',
+		null: 'not null',
+		function: () => 'new method',
+		object: {
+			prop1: 3,
+			prop2: 4,
+		},
+		array: [ 2, 3, 4, 5]
+	};
+	const changeDefaultObject = (object) => {
+		object.number = 42;
+		object.string = 'Fluffy';
+		object.undefined = 'not undefined';
+		object.null = 'not null';
+		object.function = () => 'new method';
+		object.object.prop1 = 3;
+		object.object.prop2 = 4;
+		object.array.push(5);
+		object.array.shift();
+	};
+	const compareObjectsValues = (a, b) => {
+		expect(a.number, 'Number types equal').to.equal(b.number);
+		expect(a.string, 'String types equal').to.equal(b.string);
+		expect(a.undefined, 'Undefined types equal').to.equal(b.undefined);
+		expect(a.null, 'Null types equal').to.equal(b.null);
+		expect(a.function(), 'Function out come are equal').to.equal(b.function());
+		expect(a.object, 'Object ref is not the same').to.not.equal(b.object);
+		expect(a.object.prop1, 'Inner Object props are equal').to.equal(b.object.prop1);
+		expect(a.object.prop2, 'Inner Object props are equal').to.equal(b.object.prop2);
+
+		expect(a.array, 'Array ref is not the same.').to.not.equal(b.array);
+		// Need toe check if the array values are the same and in the same order.
+		let arrayEqual = true;
+		if (a.array.length === b.array.length) {
+			for (let i = 0; i < a.array.length; i++) {
+				if (a.array[i] !== b.array[i]) arrayEqual = false;
+			}
+		} else {
+			arrayEqual = false;
+		}
+		expect(arrayEqual, 'Array values are the same.').to.be.true;
+
+	};
+	const buildDefaultObject = () => {
+		return {
+			number: 231,
+			string: 'Maya',
+			undefined: undefined,
+			null: null,
+			function: () => 'function',
+			object: {
+				prop1: 1,
+				prop2: 2,
+			},
+			array: [ 1, 2, 3, 4]
+		};
+	};
+
+	describe('Normal, Easy Cases', () => {
+		let mainObject, copiedObject;
+		beforeEach(() => {
+			mainObject = buildDefaultObject();
+			copiedObject = deepCopy(mainObject);
+		});
+
+		it('should copy a standard object.', () => {
+			expect(mainObject).to.not.equal(copiedObject);
+			compareObjectsValues(mainObject, copiedObject);
+		});
+
+		it('should not change the second object when the first one changes', () => {
+			changeDefaultObject(mainObject);
+			compareObjectsValues(copiedObject, buildDefaultObject());
+			compareObjectsValues(mainObject, changedObject);
+		});
+
+		it('should not change the first object when the second one changes', () => {
+			changeDefaultObject(copiedObject);
+			compareObjectsValues(mainObject, buildDefaultObject());
+			compareObjectsValues(copiedObject, changedObject);
+		});
+	});
+
+	describe('Cycle testing', () => {
+		let mainObject, copiedObject;
+		beforeEach(() => {
+			mainObject = buildDefaultObject();
+			mainObject.cycle = mainObject;
+			copiedObject = deepCopy(mainObject);
+		});
+
+		it('should deep copy with a cycle in the objects.', () => {
+			expect(mainObject, 'First object should be the same as cycle object.').to.equal(mainObject.cycle);
+			expect(copiedObject, 'Second object should be the same as cycle object.').to.equal(copiedObject.cycle);
+			expect(mainObject.cycle, 'Cycles objects should be different for each type.').to.not.equal(copiedObject.cycle);
+		});
+
+		it('should copy cycled objects such that if main object changes so does the cycled one and doesn\'t change the copied item.', () => {
+			changeDefaultObject(mainObject);
+			compareObjectsValues(copiedObject, buildDefaultObject());
+			compareObjectsValues(mainObject, changedObject);
+		});
+
+		it('should copy cycled objects such that if copied object changes so does the cycled one and doesn\'t change the main item.', () => {
+			changeDefaultObject(copiedObject);
+			compareObjectsValues(mainObject, buildDefaultObject());
+			compareObjectsValues(copiedObject, changedObject);
+		});
+
+		it('should update main object when changing the cycle object on the main object but not update the copied object', () => {
+			changeDefaultObject(mainObject.cycle);
+			compareObjectsValues(copiedObject, buildDefaultObject());
+			compareObjectsValues(mainObject, changedObject);
+		});
+
+		it('should update copied object when changing the cycle object on the copied object but not update the main object', () => {
+			changeDefaultObject(copiedObject.cycle);
+			compareObjectsValues(mainObject, buildDefaultObject());
+			compareObjectsValues(copiedObject, changedObject);
+		});
+	});
+});


### PR DESCRIPTION
If there was a cycle in objects we were deep copying we would receive a stackover flow. So I fixed it and added tests to deep copy and how we expect things to work.