### PR TITLE
Add support for custom observable support

### DIFF
--- a/state/observable/sirenObservableFactory.js
+++ b/state/observable/sirenObservableFactory.js
@@ -15,7 +15,8 @@ export const observableTypes = Object.freeze({
 	entity: 5,
 	subEntity: 6,
 	action: 7,
-	summonAction: 8
+	summonAction: 8,
+	custom: 9
 });
 
 const observableClasses = Object.freeze({
@@ -33,14 +34,23 @@ const observableClasses = Object.freeze({
  *
  * @param {*} param0
  */
-function definedProperty({ observable: type, prime, rel: id, route, token, state }) {
+function definedProperty({ observable: type, observableObject: typeObject, prime, rel: id, route, token, state }) {
 	return {
 		id,
 		route,
 		token: (prime || route) ? token : undefined,
 		type,
+		typeObject,
 		state
 	};
+}
+
+function getObservableObject(observableType, observableCustomObject) {
+	if (observableType === observableTypes.custom) {
+		return observableCustomObject;
+	}
+	return observableType && observableClasses[observableType];
+
 }
 
 function handleRouting(observerProperties) {
@@ -52,7 +62,7 @@ function handleRouting(observerProperties) {
 
 export function sirenObserverDefinedProperty(observerProperties, state) {
 	observerProperties = handleRouting(observerProperties);
-	const sirenObserverType = observerProperties.observable && observableClasses[observerProperties.observable];
+	const sirenObserverType = getObservableObject(observerProperties.observable, observerProperties.observableObject);
 	if (!sirenObserverType) {
 		return;
 	}
@@ -63,7 +73,7 @@ export function sirenObserverDefinedProperty(observerProperties, state) {
 }
 
 export function sirenObservableFactory(componentProperties) {
-	const sirenComponentType = componentProperties.type && observableClasses[componentProperties.type];
+	const sirenComponentType = getObservableObject(componentProperties.type, componentProperties.typeObject);
 	if (!sirenComponentType) {
 		throw new Error('Bad siren component');
 	}


### PR DESCRIPTION
So basically, adding support for custom observable types. So one can observe a property like this:

```
import { W2DSirenClasses } from './w2dDateCategoryObserver.js';
...
// W2DSirenClasses sets an array of classes.
_classes: { type: String, observable: observableTypes.custom, observableObject: W2DSirenClasses, method: (classes) => classes.pop() 
```

Tested on my local machine using a component and custom class.

For testing you can use this branch: https://github.com/BrightspaceHypermediaComponents/foundation-components/tree/maya/customObservableTest