### PR TITLE
fix: we haven't been paying attention to subentities relationships. 

### DIFF
--- a/state/HypermediaState.js
+++ b/state/HypermediaState.js
@@ -200,7 +200,9 @@ class HypermediaState extends Fetchable(Object) {
 		const routedStates = [];
 		this._decodedEntity.forEach(typeMap => {
 			typeMap.forEach(sirenObservable => {
-				sirenObservable.routedState && routedStates.push(sirenObservable.routedState);
+				if (!sirenObservable.routedState) return;
+				sirenObservable = Array.isArray(sirenObservable.routedState) ? sirenObservable.routedState : [sirenObservable.routedState];
+				sirenObservable.forEach(routedState => routedState && routedStates.push(routedState));
 			});
 		});
 		return routedStates;

--- a/state/observable/SirenLink.js
+++ b/state/observable/SirenLink.js
@@ -46,7 +46,7 @@ export class SirenLink extends Routable(Observable) {
 				this.routedState.addObservables(observer, route);
 			});
 
-			(this.routedState.hasServerResponseCached && this.routedState.hasServerResponseCached()) || fetch(this.routedState);
+			await fetch(this.routedState);
 		}
 	}
 

--- a/state/observable/SirenLink.js
+++ b/state/observable/SirenLink.js
@@ -46,7 +46,7 @@ export class SirenLink extends Routable(Observable) {
 				this.routedState.addObservables(observer, route);
 			});
 
-			await fetch(this.routedState);
+			fetch(this.routedState);
 		}
 	}
 

--- a/state/observable/SirenSubEntities.js
+++ b/state/observable/SirenSubEntities.js
@@ -46,6 +46,12 @@ export class SirenSubEntities extends Observable {
 		return this._rel;
 	}
 
+	get routedState() {
+		const routedStates = [];
+		this.entityMap.forEach(subEntity => subEntity.routedState && routedStates.push(subEntity.routedState));
+		return routedStates;
+	}
+
 	async setSirenEntity(sirenParsedEntity) {
 		const subEntities = sirenParsedEntity && sirenParsedEntity.getSubEntitiesByRel(this._rel);
 		const entityMap = new Map();

--- a/state/observable/SirenSubEntity.js
+++ b/state/observable/SirenSubEntity.js
@@ -70,7 +70,7 @@ export class SirenSubEntity extends Routable(Observable) {
 				this._routedState.addObservables(observer, route);
 			});
 
-			(this.routedState.hasServerResponseCached && this.routedState.hasServerResponseCached()) || fetch(this._routedState);
+			await fetch(this._routedState);
 		}
 	}
 

--- a/state/observable/SirenSubEntity.js
+++ b/state/observable/SirenSubEntity.js
@@ -70,7 +70,7 @@ export class SirenSubEntity extends Routable(Observable) {
 				this._routedState.addObservables(observer, route);
 			});
 
-			await fetch(this._routedState);
+			fetch(this._routedState);
 		}
 	}
 


### PR DESCRIPTION
This is a defect:https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F518693719340
It shows up using this branch: https://github.com/Brightspace/quiz-components/tree/US124788/state_push_fix


The issue is we want to call push on the parent and for it to look at all of it children. But right now the children are subentities and well, that wasn't supported / didn't work. This is to fix that problem.

I've been testing this since last Friday on my local instance and has been working!