### PR TITLE
fix: Sending token when it isn't required

### DIFF
--- a/state/observable/sirenObservableFactory.js
+++ b/state/observable/sirenObservableFactory.js
@@ -41,7 +41,7 @@ function definedProperty({ observable: type, observableObject: typeObject, prime
 	return {
 		id,
 		route,
-		token: (prime || route) ? token : undefined,
+		token: (prime || (route && route.length !== 0)) ? token : undefined,
 		type,
 		typeObject,
 		state


### PR DESCRIPTION
Basically, we were priming things that shouldn't be primed!