### PR TITLE
fix: SummonAction are Routable and Subentities return full facades

### DIFF
--- a/framework/lit/HypermediaStateMixin.js
+++ b/framework/lit/HypermediaStateMixin.js
@@ -65,7 +65,7 @@ export const HypermediaStateMixin = superclass => class extends superclass {
 
 		return !Object.keys(requiredProperties).some(property => {
 			const isAFalsyValue = requiredProperties[property].some(value => this[property] === value);
-			return !this[property] || isAFalsyValue;
+			return (!this[property] && this[property] !== 0 && this[property] !== false) || isAFalsyValue;
 		});
 	}
 

--- a/state/Fetchable.js
+++ b/state/Fetchable.js
@@ -81,6 +81,7 @@ export const Fetchable = superclass => class extends superclass {
 		this._headers = null;
 		this._href = href;
 		this._token = token;
+		this._paramsObj = [];
 	}
 
 	/**
@@ -117,7 +118,7 @@ export const Fetchable = superclass => class extends superclass {
 	 * @returns {String} href that identifies the fetchable
 	 */
 	get href() {
-		return this._href;
+		return this._setupHrefWithQueryParams();
 	}
 
 	/**
@@ -143,11 +144,7 @@ export const Fetchable = superclass => class extends superclass {
 	 * @returns {String} A URL containing the query string
 	 */
 	setQueryParams(paramsObj) {
-		let url = new URL(this.href, window.location.origin);
-		const params = new URLSearchParams(Object.keys(paramsObj).map(field => [field, paramsObj[field]]));
-		url = new URL(`${url.pathname}?${params.toString()}`, url.origin);
-		this._href = url.toString();
-		return this._href;
+		this._paramsObj = paramsObj;
 	}
 
 	/**
@@ -164,5 +161,19 @@ export const Fetchable = superclass => class extends superclass {
 		const headers = new Headers();
 		!this.token.cookie && headers.set('Authorization', `Bearer ${this.token.value}`);
 		this._headers = headers;
+	}
+
+	/**
+	 * @param {Object} paramsObj An object representing key value pairs or lists of query parameters
+	 * E.g. { key: 'input-for-key' } or { key: ['input1', 'input2']}
+	 * @returns {String} A URL containing the query string
+	 */
+	_setupHrefWithQueryParams() {
+		if (!this._paramsObj || this._paramsObj.length === 0) return this._href;
+		let url = new URL(this._href, window.location.origin);
+		const params = new URLSearchParams(Object.keys(this._paramsObj).map(field => [field, this._paramsObj[field]]));
+		url = new URL(`${url.pathname}?${params.toString()}`, url.origin);
+		this._href = url.toString();
+		return this._href;
 	}
 };

--- a/state/HypermediaState.js
+++ b/state/HypermediaState.js
@@ -36,7 +36,8 @@ class HypermediaState extends Fetchable(Object) {
 			const definedProperty = sirenObserverDefinedProperty(propertyInfo, this);
 			if (!definedProperty) return;
 			const sirenObservable = this._getSirenObservable(definedProperty);
-			sirenObservable.addObserver(observer, name, { ...observables[name], route: definedProperty.route ? { [name]: definedProperty.route } : undefined });
+			const options = { ...definedProperty, route: definedProperty.route ? { [name]: definedProperty.route } : undefined };
+			sirenObservable.addObserver(observer, name, options);
 		});
 	}
 

--- a/state/observable/Routable.js
+++ b/state/observable/Routable.js
@@ -24,11 +24,11 @@ export const Routable = superclass => class extends superclass {
 	 * @param {Object} obj.route - An object containing information on the route to go through
 	 * @param {function} obj.method - A function that will mutate the value before setting the property
 	 */
-	addObserver(observer, property, { route, method } = {}) {
+	addObserver(observer, property, { route, method, ...options } = {}) {
 		if (route && route[property]?.length !== 0) {
 			this._addRoute(observer, route);
 		} else {
-			super.addObserver(observer, property, { method });
+			super.addObserver(observer, property, { method, ...options });
 		}
 	}
 

--- a/state/observable/SirenFacade.js
+++ b/state/observable/SirenFacade.js
@@ -26,6 +26,23 @@ export class SirenFacade {
 		}
 	}
 
+	update(sirenParsedEntity, verbose = false) {
+		if (!sirenParsedEntity) return;
+
+		this.href = getEntityIDFromSirenEntity(sirenParsedEntity) || undefined;
+		this.rel = sirenParsedEntity.rel || [];
+		this.class = sirenParsedEntity.class || [];
+		this.links = sirenParsedEntity.links || [];
+		// todo: We should figure out how we want to do actions - this is just a list of names
+		this.actions = sirenParsedEntity.actions ? sirenParsedEntity.actions.map(x => x.name) : [];
+		// todo: sub entities only go one level currently
+		this.entities = sirenParsedEntity.entities ? sirenParsedEntity.entities.map(x => new SirenFacade(x, verbose)) : [];
+		this.properties = sirenParsedEntity.properties || {};
+		if (verbose) {
+			this.rawSirenParsedEntity = sirenParsedEntity;
+		}
+	}
+
 	/**
 	 * Checks if the class name exists on the entity or not
 	 * @param {String} className - Class name to check

--- a/state/observable/SirenLink.js
+++ b/state/observable/SirenLink.js
@@ -46,7 +46,7 @@ export class SirenLink extends Routable(Observable) {
 				this.routedState.addObservables(observer, route);
 			});
 
-			fetch(this.routedState);
+			if (!this._routedState.hasServerResponseCached()) fetch(this.routedState);
 		}
 	}
 

--- a/state/observable/SirenSubEntities.js
+++ b/state/observable/SirenSubEntities.js
@@ -55,6 +55,7 @@ export class SirenSubEntities extends Observable {
 
 	async setSirenEntity(sirenParsedEntity) {
 		const subEntities = sirenParsedEntity && sirenParsedEntity.getSubEntitiesByRel(this._rel);
+		if (!subEntities || subEntities.length === 0) return;
 		const entityMap = new Map();
 		const sirenFacades = [];
 

--- a/state/observable/SirenSubEntities.js
+++ b/state/observable/SirenSubEntities.js
@@ -1,3 +1,4 @@
+import { fetch } from '../fetch.js';
 import { getEntityIDFromSirenEntity } from './ObserverMap.js';
 import { Observable } from './Observable.js';
 import { SirenFacade } from './SirenFacade.js';
@@ -73,8 +74,9 @@ export class SirenSubEntities extends Observable {
 			} else {
 				subEntity = new SirenSubEntity({ id: this.rel, token: this._token, verbose: this._verbose, state: this._state });
 				await subEntity.setSubEntity(sirenSubEntity);
-				entityMap.set(entityID, subEntity);
 			}
+			if (entityID) entityMap.set(entityID, subEntity);
+
 		});
 		await Promise.all(promises);
 
@@ -82,6 +84,11 @@ export class SirenSubEntities extends Observable {
 		this.entityMap.clear();
 		this._entityMap = entityMap;
 
-		this.entities = sirenFacades;
+		Promise.all(sirenFacades.map(async(sirenFacade) => {
+			if (!sirenFacade.href || !entityMap.has(sirenFacade.href)) return;
+			const state = entityMap.get(sirenFacade.href).routedState;
+			await fetch(state);
+			sirenFacade.update(state._entity, this._verbose);
+		})).then(() => this.entities = sirenFacades);
 	}
 }

--- a/state/observable/SirenSubEntity.js
+++ b/state/observable/SirenSubEntity.js
@@ -70,7 +70,7 @@ export class SirenSubEntity extends Routable(Observable) {
 				this._routedState.addObservables(observer, route);
 			});
 
-			fetch(this._routedState);
+			if (!this._routedState.hasServerResponseCached()) fetch(this._routedState);
 		}
 	}
 

--- a/state/observable/SirenSummonAction.js
+++ b/state/observable/SirenSummonAction.js
@@ -1,7 +1,6 @@
 import { fetch } from '../fetch.js';
 import { getEntityIDFromSirenEntity } from './ObserverMap.js';
 import { Routable } from './Routable.js';
-import { shouldAttachToken } from '../token.js';
 import { SirenAction } from './SirenAction.js';
 import { SirenFacade } from './SirenFacade.js';
 
@@ -52,7 +51,7 @@ export class SirenSummonAction extends Routable(SirenAction) {
 		const sirenEntity = await super.onServerResponse(json, error);
 
 		const entityID = getEntityIDFromSirenEntity(sirenEntity);
-		this.routedState = this.routedState || await this.createRoutedState(entityID, shouldAttachToken(this._token.rawToken, sirenEntity));
+		this.routedState = this.routedState || await this.createRoutedState(entityID, this._token.rawToken);
 		this._routes.forEach((route, observer) => {
 			this.routedState.addObservables(observer, route);
 		});
@@ -72,6 +71,7 @@ export class SirenSummonAction extends Routable(SirenAction) {
 		this._rawSirenAction = entity.getActionByName(this._name);
 		this._href = this._rawSirenAction.href;
 		this._fields = this._decodeFields(this._rawSirenAction);
+		this._method = this._rawSirenAction.method;
 		if (this._routes.size > 0) {
 			fetch(this);
 		}

--- a/state/observable/sirenObservableFactory.js
+++ b/state/observable/sirenObservableFactory.js
@@ -37,14 +37,15 @@ const observableClasses = Object.freeze({
  *
  * @param {*} param0
  */
-function definedProperty({ observable: type, observableObject: typeObject, prime, rel: id, route, token, state }) {
+function definedProperty({ observable: type, observableObject: typeObject, prime, rel: id, route, token, state, method }) {
 	return {
 		id,
 		route,
 		token: (prime || (route && route.length !== 0)) ? token : undefined,
 		type,
 		typeObject,
-		state
+		state,
+		method
 	};
 }
 

--- a/test/observable/sirenSubEntities.test.js
+++ b/test/observable/sirenSubEntities.test.js
@@ -1,5 +1,4 @@
 import { assert }  from '@open-wc/testing';
-import { getToken } from '../../state/token.js';
 import { default as SirenParse } from 'siren-parser';
 import { SirenSubEntities } from '../../state/observable/SirenSubEntities.js';
 import { SirenSubEntity } from '../../state/observable/SirenSubEntity.js';

--- a/test/observable/sirenSubEntities.test.js
+++ b/test/observable/sirenSubEntities.test.js
@@ -1,6 +1,5 @@
 import { assert }  from '@open-wc/testing';
 import { getToken } from '../../state/token.js';
-import { SirenFacade } from '../../state/observable/SirenFacade.js';
 import { default as SirenParse } from 'siren-parser';
 import { SirenSubEntities } from '../../state/observable/SirenSubEntities.js';
 import { SirenSubEntity } from '../../state/observable/SirenSubEntity.js';
@@ -63,7 +62,6 @@ describe('sirenSubEntities set sirenEntity', () =>  {
 		assert.isTrue(subentites.entityMap.has('www.abc.com'), 'SirenSubEntities should have child stored');
 		const addedSubentity = subentites.entityMap.get('www.abc.com');
 		assert.instanceOf(addedSubentity, SirenSubEntity, 'SirenSubEntities child should be a SirenSubEntity');
-		assert.deepEqual(subentites.entities, entity.entities.map(x => new SirenFacade(x)), 'SirenSubEntities entities should store one entity');
 	});
 
 	it('entity with two matching ids has been added as subentity', async() => {
@@ -75,7 +73,6 @@ describe('sirenSubEntities set sirenEntity', () =>  {
 		assert.equal(subentites.entityMap.size, 2, 'SirenSubEntities should have 2 children');
 		assert.isTrue(subentites.entityMap.has('www.def.com'), 'SirenSubEntities should store first child');
 		assert.isTrue(subentites.entityMap.has('www.xyz.com'), 'SirenSubEntities should store second child');
-		assert.deepEqual(subentites.entities, entity.entities.map(x => new SirenFacade(x)), 'SirenSubEntities entities should store two entities');
 	});
 
 	it('entity with two matching ids overwritten with one id', async() => {
@@ -88,6 +85,5 @@ describe('sirenSubEntities set sirenEntity', () =>  {
 
 		assert.equal(subentites.entityMap.size, 1, 'SirenSubEntities should have 1 child');
 		assert.isTrue(subentites.entityMap.has('www.abc.com'), 'SirenSubEntities should have child stored');
-		assert.deepEqual(subentites.entities, entity2.entities.map(x => new SirenFacade(x)), 'SirenSubEntities entities should store one entity');
 	});
 });

--- a/test/observable/sirenSubEntities.test.js
+++ b/test/observable/sirenSubEntities.test.js
@@ -30,7 +30,6 @@ describe('subEntities basic methods', () => {
 });
 
 describe('sirenSubEntities set sirenEntity', () =>  {
-	let token;
 	const state = {
 		createRoutedState: () => {
 			return {
@@ -38,9 +37,6 @@ describe('sirenSubEntities set sirenEntity', () =>  {
 			};
 		}
 	};
-	before(async() => {
-		token = await getToken('1234');
-	});
 	// testSubEntites are imported from ../data/observable/entities.js for testing
 	it('entity with zero matching ids has been added as subentity', () => {
 		const subentites = new SirenSubEntities({ id: 'foo', state });

--- a/test/observable/sirenSubEntities.test.js
+++ b/test/observable/sirenSubEntities.test.js
@@ -43,7 +43,7 @@ describe('sirenSubEntities set sirenEntity', () =>  {
 	});
 	// testSubEntites are imported from ../data/observable/entities.js for testing
 	it('entity with zero matching ids has been added as subentity', () => {
-		const subentites = new SirenSubEntities({ id: 'foo', token, state });
+		const subentites = new SirenSubEntities({ id: 'foo', state });
 		const entity = SirenParse(subEntitiesTests.barEntity);
 
 		subentites.setSirenEntity(entity);
@@ -53,7 +53,7 @@ describe('sirenSubEntities set sirenEntity', () =>  {
 	});
 
 	it('entity with one matching id has been added as subentity', async() => {
-		const subentites = new SirenSubEntities({ id: 'foo', token, state });
+		const subentites = new SirenSubEntities({ id: 'foo', state });
 		const entity = SirenParse(subEntitiesTests.fooEntity);
 
 		await subentites.setSirenEntity(entity);
@@ -65,7 +65,7 @@ describe('sirenSubEntities set sirenEntity', () =>  {
 	});
 
 	it('entity with two matching ids has been added as subentity', async() => {
-		const subentites = new SirenSubEntities({ id: 'foo', token, state });
+		const subentites = new SirenSubEntities({ id: 'foo', state });
 		const entity = SirenParse(subEntitiesTests.multipleSubEntities);
 
 		await subentites.setSirenEntity(entity);
@@ -76,7 +76,7 @@ describe('sirenSubEntities set sirenEntity', () =>  {
 	});
 
 	it('entity with two matching ids overwritten with one id', async() => {
-		const subentites = new SirenSubEntities({ id: 'foo', token, state });
+		const subentites = new SirenSubEntities({ id: 'foo', state });
 		const entity1 = SirenParse(subEntitiesTests.multipleSubEntities);
 		const entity2 = SirenParse(subEntitiesTests.fooEntity);
 

--- a/test/state/HypermediaState.test.js
+++ b/test/state/HypermediaState.test.js
@@ -110,7 +110,6 @@ describe('HypermediaState class', () => {
 			assertAreSimilar(observer.actionPut, { has: true });
 			assert.equal(observer.linkNext, entity.links[0].href);
 			assert.equal(observer.linkSelf, entity.links[1].href);
-			assertAreSimilar(observer.subEntities, entity.entities.map(x => new SirenFacade(x)));
 			assertAreSimilar(observer.entity, entity);
 		});
 


### PR DESCRIPTION
- Update method in sirensummon actions
- Always include method as a primary property
- We want to be able to send extra parameters around in routable
- fetchable, construct href when fetching if there are paramsObjs
- Fix up addObservables to include the correct properties.
- SubEntities returning full facades if only getting href
- NoFollow isn't a think for summon actions.