### PR TITLE
fix: Routing when already fetched

### DIFF
--- a/state/observable/Routable.js
+++ b/state/observable/Routable.js
@@ -47,6 +47,9 @@ export const Routable = superclass => class extends superclass {
 	_addRoute(observer, route) {
 		const currentRoute = this._routes.has(observer) ? this._routes.get(observer) : {};
 		this._routes.set(observer, { ...currentRoute, ...route });
+		if (this._routedState) {
+			this._routedState.addObservables(observer, route);
+		}
 	}
 
 	_deleteRoute(observer) {


### PR DESCRIPTION
When adding a new observer with a routed state to an observer that already fetched it `routedState` then add the new observer to the `routedState`