### PR TITLE
feat: Add bypassCache and tests to summon action

### DIFF
--- a/state/observable/SirenSummonAction.js
+++ b/state/observable/SirenSummonAction.js
@@ -81,11 +81,15 @@ export class SirenSummonAction extends Routable(SirenAction) {
 	_updateAction() {
 		this.action = {
 			has: true,
-			summon: async(observables) => {
+			summon: async(observables, bypassCache) => {
 				this._prepareAction(observables);
 				this._readyToSend = true;
-				// todo: we should be able to just return what we get back from fetch, but it is returning the json
-				await fetch(this);
+
+				const response = await fetch(this);
+				if (bypassCache) {
+					return response;
+				}
+
 				return new SirenFacade(this.routedState._entity, this._verbose);
 			}
 		};

--- a/state/observable/SirenSummonAction.js
+++ b/state/observable/SirenSummonAction.js
@@ -85,11 +85,10 @@ export class SirenSummonAction extends Routable(SirenAction) {
 				this._prepareAction(observables);
 				this._readyToSend = true;
 
-				const response = await fetch(this);
-				if (bypassCache) {
-					return response;
+				if (bypassCache && this.routedState) {
+					this.routedState.byPassCache();
 				}
-
+				await fetch(this);
 				return new SirenFacade(this.routedState._entity, this._verbose);
 			}
 		};

--- a/test/example-components/summon-action-components.js
+++ b/test/example-components/summon-action-components.js
@@ -9,9 +9,9 @@ class SummonActionComponent extends HypermediaStateMixin(LitElement) {
 		};
 	}
 
-	async getSummonedThing() {
+	async getSummonedThing(observables, bypassCache) {
 		if (this._hasAction('exampleSummon')) {
-			this.summonedEntity = await this.exampleSummon.summon();
+			this.summonedEntity = await this.exampleSummon.summon(observables, bypassCache);
 		}
 	}
 }


### PR DESCRIPTION
Adds a `bypassCache` boolean argument to the `summonAction.summon()` function. 
Also adds two tests to confirm that the cached/bypassed calls are caching and bypassing as expected.

I also tested this manually by linking up with the summon action for the [Enrollment Rule match count mixin](https://github.com/BrightspaceHypermediaComponents/foundation-components/blob/5b1a0e01759305ff8937fe34455a265c40fff430/features/discover/mixins/match-count-mixin.js#L28) and reviewing the behavior when the argument is set/unset. This PR is needed to prevent it from caching the first returned count value.
